### PR TITLE
feat: support parsing folder name from .torrent

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You find the docker image on the right side under "Packages"
 
 See `docker-compose.yml` for an example.
 
-Make sure you use the correct path you have mapped within the container in the config file. After the first start you will need to setup the created config file in your config directory and start the container again.
+Make sure you use the correct path you have mapped within the container in the config file. After the first start you will need to set up the created config file in your config directory and start the container again.
 
 ## autobrr Filter setup
 
@@ -109,7 +109,21 @@ After adding this filter, you need to go to the `External` tab and enable the `W
   "name":"{{ .TorrentName | js }}" }
 ```
 
-Next you need to go to the `Actions` tab and select qBittorrent as the `Client` and your Sonarr pre import category in the `Category` field. Last but not least, you should leave `Skip Hash Check` disabled to prevent any torrents added by seasonpackarr from erroring in your qBittorrent client when you are missing some episodes of a season.
+Next you need to go to the `Actions` tab, click on `Add new` and select `qBittorrent` in the `Type` and your configured qBittorrent client in the `Client` field. If you use seasonpackarr together with Sonarr you can input the pre import category in the `Category` field to make sure it picks up the season pack.
+
+If you want to extract the correct folder name from the .torrent file and not from the announce name to make sure that it's always correct, you will need to set the config option `parseTorrentFile` to `true`. Additionally, you need to create a new action, select `Webhook` in the `Type` field, with `Host` looking like this, replacing the host and port with the ones from your config: `http://<host>:<port>/api/push`. Finally `Data (JSON)` needs to be filled with this, where the variables need to be replaced by your information:
+
+```
+{ "host":"http://<qbit_host>:<qbit_port>",
+  "user":"<qbit_user>",
+  "password":"<qbit_pass>",
+  "name":"{{ .TorrentName | js }}" 
+  "torrentpath":"{{ .TorrentPathName | js }}" }
+```
+
+You need to make sure that the `Webhook` action is the first one in your list followed by the `qBittorrent` action.
+
+Last but not least, you should leave `Skip Hash Check` disabled to prevent any torrents added by seasonpackarr from erroring in your qBittorrent client when you are missing some episodes of a season.
 
 > **Warning**
 > If you enable that option regardless, you will most likely have to deal with errored torrents, which would require you to manually trigger a recheck on them to fix the issue.

--- a/config.toml
+++ b/config.toml
@@ -18,3 +18,10 @@ port = 42069
 # Default: ""
 #
 preImportPath = ""
+
+# Boolean value to decide if the torrent file should be parsed for folder naming
+# autobrr filter needs to be adjusted according to the readme
+#
+# Default: false
+#
+parseTorrentFile = false

--- a/config/config.go
+++ b/config/config.go
@@ -13,9 +13,10 @@ import (
 )
 
 type Config struct {
-	Host          string
-	Port          int
-	PreImportPath string
+	Host             string
+	Port             int
+	PreImportPath    string
+	ParseTorrentFile bool
 }
 
 var (
@@ -43,6 +44,13 @@ port = {{ .Port }}
 # Default: ""
 #
 preImportPath = "{{ .PreImportPath }}"
+
+# Boolean value to decide if the torrent file should be parsed for folder naming
+# autobrr filter needs to be adjusted according to the readme
+#
+# Default: false
+#
+parseTorrentFile = {{ .ParseTorrentFile }}
 `
 
 func init() {
@@ -57,9 +65,10 @@ func init() {
 
 func InitConfig() {
 	defaultConfig := Config{
-		Host:          "0.0.0.0",
-		Port:          42069,
-		PreImportPath: "",
+		Host:             "0.0.0.0",
+		Port:             42069,
+		PreImportPath:    "",
+		ParseTorrentFile: false,
 	}
 
 	tmpl, err := template.New("config").Parse(configTemplate)
@@ -96,10 +105,10 @@ func InitConfig() {
 	}
 
 	if viper.GetString("PreImportPath") == "" {
-		log.Fatal().Msg("PreImportPath can't be empty, please provide a valid path to your pre import torrent directory")
+		log.Fatal().Msg("preImportPath can't be empty, please provide a valid path to your pre import torrent directory")
 	}
 
 	if _, err := os.Stat(viper.GetString("PreImportPath")); os.IsNotExist(err) {
-		log.Fatal().Err(err).Msg("PreImportPath doesn't exist, please make sure you entered the correct path")
+		log.Fatal().Err(err).Msg("preImportPath doesn't exist, please make sure you entered the correct path")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/autobrr/go-qbittorrent v1.3.1
 	github.com/go-chi/chi/v5 v5.0.8
+	github.com/j-muller/go-torrent-parser v0.0.0-20211014072822-db02b4099054
 	github.com/moistari/rls v0.5.9
 	github.com/rs/zerolog v1.29.1
 	github.com/spf13/pflag v1.0.5
@@ -28,6 +29,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
+	github.com/zeebo/bencode v1.0.0 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/j-muller/go-torrent-parser v0.0.0-20211014072822-db02b4099054 h1:74rPb7GmzJVJkSQ1Tpd7Y8iCnNveIjnpgyos4Yu4Gzs=
+github.com/j-muller/go-torrent-parser v0.0.0-20211014072822-db02b4099054/go.mod h1:mMeMpHRplLTgo3ttLVB8R43jtdEKcDpLVw2CvcwTv28=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -190,6 +192,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zeebo/bencode v1.0.0 h1:zgop0Wu1nu4IexAZeCZ5qbsjU4O1vMrfCrVgUjbHVuA=
+github.com/zeebo/bencode v1.0.0/go.mod h1:Ct7CkrWIQuLWAy9M3atFHYq4kG9Ao/SsY5cdtCXmp9Y=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
Added support for parsing the .torrent file that you can request from autobrr to always get the correct folder name of the season pack. Parsing logic can be changed by changing `parseTorrentFile` in the config file from the default value `false` to `true`.

Fixes #21 and fixes #23 
