### PR TITLE
feat: add test commands

### DIFF
--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -13,7 +13,7 @@ import (
 
 // packCmd represents the test command
 var packCmd = &cobra.Command{
-	Use:   "test",
+	Use:   "pack",
 	Short: "Test the pack api endpoint for a specified release",
 	Run: func(cmd *cobra.Command, args []string) {
 		body, err := payload.CompileParsePayload(rlsName, nil, clientName)

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2023 - 2024, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package cmd
+
+import (
+	"fmt"
+
+	"seasonpackarr/internal/payload"
+
+	"github.com/spf13/cobra"
+)
+
+// packCmd represents the test command
+var packCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test the pack api endpoint for a specified release",
+	Run: func(cmd *cobra.Command, args []string) {
+		body, err := payload.CompileParsePayload(rlsName, nil, clientName)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
+		err = payload.ExecRequest(fmt.Sprintf("http://%s:%d/api/pack", host, port), body, apiKey)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+	},
+}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2023 - 2024, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package cmd
+
+import (
+	"fmt"
+
+	"seasonpackarr/internal/payload"
+	"seasonpackarr/internal/torrents"
+
+	"github.com/spf13/cobra"
+)
+
+// parseCmd represents the test command
+var parseCmd = &cobra.Command{
+	Use:   "parse",
+	Short: "Test the parse api endpoint for a specified release",
+	Run: func(cmd *cobra.Command, args []string) {
+		torrentBytes, err := torrents.TorrentFromRls(rlsName, 5)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
+		body, err := payload.CompileParsePayload(rlsName, torrentBytes, clientName)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+
+		err = payload.ExecRequest(fmt.Sprintf("http://%s:%d/api/parse", host, port), body, apiKey)
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,9 +35,14 @@ For more information and examples, visit https://github.com/nuxencs/seasonpackar
 func init() {
 	startCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to configuration directory")
 
-	rootCmd.AddCommand(genTokenCmd, startCmd, testCmd, versionCmd)
+	testCmd.PersistentFlags().StringVarP(&rlsName, "rls", "r", "", "name of the release you want to test")
+	testCmd.PersistentFlags().StringVarP(&clientName, "client", "n", "", "name of the client you want to test")
+	testCmd.PersistentFlags().StringVarP(&host, "host", "i", "127.0.0.1", "host used by seasonpackarr")
+	testCmd.PersistentFlags().IntVarP(&port, "port", "p", 42069, "port used by seasonpackarr")
+	testCmd.PersistentFlags().StringVarP(&apiKey, "api", "a", "", "api key used by seasonpackarr")
+	_ = testCmd.MarkPersistentFlagRequired("rls")
 
-	addTestFlags(packCmd, parseCmd)
+	rootCmd.AddCommand(genTokenCmd, startCmd, testCmd, versionCmd)
 
 	testCmd.AddCommand(packCmd, parseCmd)
 }
@@ -46,17 +51,5 @@ func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
-	}
-}
-
-func addTestFlags(cmds ...*cobra.Command) {
-	for _, cmd := range cmds {
-		cmd.Flags().StringVarP(&rlsName, "rls", "r", "", "name of the release you want to test")
-		cmd.Flags().StringVarP(&clientName, "client", "n", "", "name of the client you want to test")
-		cmd.Flags().StringVarP(&host, "host", "i", "127.0.0.1", "host used by seasonpackarr")
-		cmd.Flags().IntVarP(&port, "port", "p", 42069, "port used by seasonpackarr")
-		cmd.Flags().StringVarP(&apiKey, "api", "a", "", "api key used by seasonpackarr")
-
-		_ = cmd.MarkFlagRequired("rls")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,7 +9,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var configPath string
+var (
+	configPath string
+	rlsName    string
+	clientName string
+	host       string
+	port       int
+	apiKey     string
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "seasonpackarr",
@@ -28,14 +35,28 @@ For more information and examples, visit https://github.com/nuxencs/seasonpackar
 func init() {
 	startCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to configuration directory")
 
-	rootCmd.AddCommand(genTokenCmd)
-	rootCmd.AddCommand(startCmd)
-	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(genTokenCmd, startCmd, testCmd, versionCmd)
+
+	addTestFlags(packCmd, parseCmd)
+
+	testCmd.AddCommand(packCmd, parseCmd)
 }
 
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
+	}
+}
+
+func addTestFlags(cmds ...*cobra.Command) {
+	for _, cmd := range cmds {
+		cmd.Flags().StringVarP(&rlsName, "rls", "r", "", "name of the release you want to test")
+		cmd.Flags().StringVarP(&clientName, "client", "n", "", "name of the client you want to test")
+		cmd.Flags().StringVarP(&host, "host", "i", "127.0.0.1", "host used by seasonpackarr")
+		cmd.Flags().IntVarP(&port, "port", "p", 42069, "port used by seasonpackarr")
+		cmd.Flags().StringVarP(&apiKey, "api", "a", "", "api key used by seasonpackarr")
+
+		_ = cmd.MarkFlagRequired("rls")
 	}
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 - 2024, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// testCmd represents the test command
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test a specified feature",
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/anacrolix/torrent v1.55.0
 	github.com/autobrr/go-qbittorrent v1.8.1
+	github.com/dlclark/regexp2 v1.11.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/render v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20180421182945-02af3965c54e/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/internal/payload/payload.go
+++ b/internal/payload/payload.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2023 - 2024, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package payload
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"text/template"
+	"time"
+)
+
+const payloadPack = `
+	{
+	  "name": "{{ .TorrentName }}",
+	  "clientname": "{{ .ClientName }}"
+	}`
+
+const payloadParse = `
+	{
+	  "name":"{{ .TorrentName }}",
+	  "torrent":"{{ .TorrentDataRawBytes }}",
+	  "clientname": "{{ .ClientName }}"
+	}`
+
+type packVars struct {
+	TorrentName string
+	ClientName  string
+}
+
+type parseVars struct {
+	TorrentName         string
+	TorrentDataRawBytes []byte
+	ClientName          string
+}
+
+func CompilePackPayload(torrentName string, clientName string) (io.Reader, error) {
+	var buffer bytes.Buffer
+
+	tmplVars := packVars{
+		TorrentName: torrentName,
+		ClientName:  clientName,
+	}
+
+	tmpl, err := template.New("Request").Parse(payloadPack)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = tmpl.Execute(&buffer, &tmplVars); err != nil {
+		return nil, err
+	}
+
+	return &buffer, nil
+}
+
+func CompileParsePayload(torrentName string, torrentBytes []byte, clientName string) (io.Reader, error) {
+	var buffer bytes.Buffer
+
+	tmplVars := parseVars{
+		TorrentName:         torrentName,
+		TorrentDataRawBytes: torrentBytes,
+		ClientName:          clientName,
+	}
+
+	tmpl, err := template.New("Request").Parse(payloadParse)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = tmpl.Execute(&buffer, &tmplVars); err != nil {
+		return nil, err
+	}
+
+	return &buffer, nil
+}
+
+func ExecRequest(url string, body io.Reader, apiToken string) error {
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-API-Token", apiToken)
+
+	c := &http.Client{Timeout: 30 * time.Second}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%v", string(respData))
+
+	return nil
+}

--- a/internal/torrents/mock.go
+++ b/internal/torrents/mock.go
@@ -1,0 +1,85 @@
+package torrents
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
+	regexp "github.com/dlclark/regexp2"
+)
+
+var seasonRegex = regexp.MustCompile(`\bS\d+\b(?!E\d+\b)`, regexp.IgnoreCase)
+
+func mockEpisodes(dir string, numEpisodes int) error {
+	match, err := seasonRegex.FindStringMatch(filepath.Base(dir))
+	if err != nil {
+		return err
+	}
+
+	if match == nil {
+		return fmt.Errorf("no season information found in release name")
+	}
+
+	season := match.String()
+
+	for i := 1; i <= numEpisodes; i++ {
+		episodeName := strings.Replace(filepath.Base(dir), season, season+fmt.Sprintf("E%02d", i), -1) + ".mkv"
+		episodePath := filepath.Join(dir, episodeName)
+
+		// Create a minimal file.
+		if err = os.WriteFile(episodePath, []byte("0"), 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func torrentFromFolder(folderPath string) ([]byte, error) {
+	mi := metainfo.MetaInfo{
+		AnnounceList: [][]string{},
+	}
+
+	info := metainfo.Info{
+		PieceLength: 256 * 1024,
+	}
+
+	err := info.BuildFromFilePath(folderPath)
+	if err != nil {
+		return nil, err
+	}
+
+	mi.InfoBytes, err = bencode.Marshal(info)
+	if err != nil {
+		return nil, err
+	}
+
+	torrentBytes := bytes.Buffer{}
+	err = mi.Write(&torrentBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return torrentBytes.Bytes(), nil
+}
+
+func TorrentFromRls(rlsName string, numEpisodes int) ([]byte, error) {
+	tempDirPath := filepath.Join(os.TempDir(), rlsName)
+
+	// Create the directory with the specified name
+	err := os.Mkdir(tempDirPath, os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tempDirPath)
+
+	if err = mockEpisodes(tempDirPath, numEpisodes); err != nil {
+		return nil, err
+	}
+
+	return torrentFromFolder(tempDirPath)
+}


### PR DESCRIPTION
This adds test commands for both the pack and the parse API endpoints to make testing them easier for the end user.