### PR TITLE
chore(cmd): add example test commands

### DIFF
--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -13,10 +13,11 @@ import (
 
 // packCmd represents the test command
 var packCmd = &cobra.Command{
-	Use:   "pack",
-	Short: "Test the pack api endpoint for a specified release",
+	Use:     "pack",
+	Short:   "Test the pack api endpoint for a specified release",
+	Example: `seasonpackarr test pack --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
 	Run: func(cmd *cobra.Command, args []string) {
-		body, err := payload.CompileParsePayload(rlsName, nil, clientName)
+		body, err := payload.CompilePackPayload(rlsName, clientName)
 		if err != nil {
 			fmt.Println(err.Error())
 			return

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -14,8 +14,9 @@ import (
 
 // parseCmd represents the test command
 var parseCmd = &cobra.Command{
-	Use:   "parse",
-	Short: "Test the parse api endpoint for a specified release",
+	Use:     "parse",
+	Short:   "Test the parse api endpoint for a specified release",
+	Example: `seasonpackarr test parse --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		torrentBytes, err := torrents.TorrentFromRls(rlsName, 5)
 		if err != nil {

--- a/internal/payload/payload.go
+++ b/internal/payload/payload.go
@@ -84,7 +84,9 @@ func ExecRequest(url string, body io.Reader, apiToken string) error {
 	}
 	req.Header.Set("X-API-Token", apiToken)
 
-	c := &http.Client{Timeout: 30 * time.Second}
+	c := &http.Client{
+		Timeout: 30 * time.Second,
+	}
 
 	resp, err := c.Do(req)
 	if err != nil {
@@ -92,12 +94,8 @@ func ExecRequest(url string, body io.Reader, apiToken string) error {
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%v", string(respData))
+	fmt.Printf("Completed the request with the following response: %s\n"+
+		"For more details take a look at the logs!", resp.Status)
 
 	return nil
 }


### PR DESCRIPTION
Add example test commands, fix a copy & paste typo and make the response for test commands clearer.