### PR TITLE
fix(processor): match filenames to seasonpack

### DIFF
--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -340,7 +340,8 @@ func (p *processor) processSeasonPack() (int, error) {
 
 			newMatches := append(oldMatches.([]matchPaths), currentMatch...)
 			matchesMap.Store(p.req.Name, newMatches)
-			p.log.Debug().Msgf("matched torrent from client: name(%s), size(%d), hash(%s)", child.T.Name, size, child.T.Hash)
+			p.log.Debug().Msgf("matched torrent from client: name(%s), size(%d), hash(%s)",
+				child.T.Name, size, child.T.Hash)
 			respCodes = append(respCodes, res)
 			continue
 		}
@@ -380,11 +381,11 @@ func (p *processor) processSeasonPack() (int, error) {
 
 	for _, match := range matches {
 		if err := utils.CreateHardlink(match.epPathClient, match.packPathAnnounce); err != nil {
-			p.log.Error().Err(err).Msgf("error creating hardlink for: %q", match.epPathClient)
+			p.log.Error().Err(err).Msgf("error creating hardlink: %s", match.epPathClient)
 			hardlinkRespCodes = append(hardlinkRespCodes, StatusFailedHardlink)
 			continue
 		}
-		p.log.Log().Msgf("created hardlink of %q into %q", match.epPathClient, match.packPathAnnounce)
+		p.log.Log().Msgf("created hardlink: source(%s), target(%s)", match.epPathClient, match.packPathAnnounce)
 		hardlinkRespCodes = append(hardlinkRespCodes, StatusSuccessfulHardlink)
 	}
 
@@ -466,24 +467,26 @@ func (p *processor) parseTorrent() (int, error) {
 		for _, torrentEp := range torrentEps {
 			matchedPath, matchErr = utils.MatchEpToSeasonPackEp(newPackPath, match.epSizeClient, torrentEp)
 			if matchErr != nil {
-				p.log.Debug().Err(matchErr).Msgf("episode did not match: client(%s), torrent(%s)", match.epPathClient, torrentEp.Name)
+				p.log.Debug().Err(matchErr).Msgf("episode did not match: client(%s), torrent(%s)",
+					filepath.Base(match.epPathClient), torrentEp.Name)
 				continue
 			}
 			break
 		}
 		if matchErr != nil {
-			p.log.Error().Err(matchErr).Msgf("error matching episode to file in pack, skipping hardlink: %q", match.epPathClient)
+			p.log.Error().Err(matchErr).Msgf("error matching episode to file in pack, skipping hardlink: %s",
+				filepath.Base(match.epPathClient))
 			hardlinkRespCodes = append(hardlinkRespCodes, StatusFailedHardlink)
 			continue
 		}
 		newPackPath = matchedPath
 
 		if err = utils.CreateHardlink(match.epPathClient, newPackPath); err != nil {
-			p.log.Error().Err(err).Msgf("error creating hardlink for: %q", match.epPathClient)
+			p.log.Error().Err(err).Msgf("error creating hardlink: %s", match.epPathClient)
 			hardlinkRespCodes = append(hardlinkRespCodes, StatusFailedHardlink)
 			continue
 		}
-		p.log.Log().Msgf("created hardlink of %q into %q", match.epPathClient, newPackPath)
+		p.log.Log().Msgf("created hardlink: source(%s), target(%s)", match.epPathClient, newPackPath)
 		hardlinkRespCodes = append(hardlinkRespCodes, StatusSuccessfulHardlink)
 	}
 

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -463,7 +463,6 @@ func (p *processor) parseTorrent() (int, error) {
 	for _, match := range matches {
 		newPackPath := utils.ReplaceParentFolder(match.packPathAnnounce, packNameParsed)
 
-		// TODO: rework this functionality as it currently leads to overwritten hardlinks
 		for _, torrentEp := range torrentEps {
 			matchedPath, matchErr = utils.MatchEpToSeasonPackEp(newPackPath, match.epSizeClient, torrentEp)
 			if matchErr != nil {

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -215,7 +215,7 @@ func (p *processor) processSeasonPack() (int, error) {
 	if !ok {
 		return StatusClientNotFound, fmt.Errorf("client not found in config")
 	}
-	p.log.Info().Msgf("using %q client serving at %s:%d", clientName, client.Host, client.Port)
+	p.log.Info().Msgf("using %s client serving at %s:%d", clientName, client.Host, client.Port)
 
 	if len(p.req.Name) == 0 {
 		return StatusAnnounceNameError, fmt.Errorf("couldn't get announce name")
@@ -237,7 +237,7 @@ func (p *processor) processSeasonPack() (int, error) {
 	}
 
 	packNameAnnounce := utils.FormatSeasonPackTitle(p.req.Name)
-	p.log.Debug().Msgf("formatted season pack name: %q", packNameAnnounce)
+	p.log.Debug().Msgf("formatted season pack name: %s", packNameAnnounce)
 
 	for _, child := range v {
 		if release.CheckCandidates(&requestrls, &child, p.cfg.Config.FuzzyMatching) == StatusAlreadyInClient {
@@ -307,7 +307,7 @@ func (p *processor) processSeasonPack() (int, error) {
 		case StatusSuccessfulMatch:
 			m, err := p.getFiles(child.T.Hash)
 			if err != nil {
-				p.log.Error().Err(err).Msgf("error getting files: %q", child.T.Name)
+				p.log.Error().Err(err).Msgf("error getting files: %s", child.T.Name)
 				continue
 			}
 
@@ -440,7 +440,7 @@ func (p *processor) parseTorrent() (int, error) {
 		return StatusParseTorrentInfoError, err
 	}
 	packNameParsed := torrentInfo.BestName()
-	p.log.Debug().Msgf("parsed season pack name: %q", packNameParsed)
+	p.log.Debug().Msgf("parsed season pack name: %s", packNameParsed)
 
 	torrentEps, err := torrents.GetEpisodesFromTorrentInfo(torrentInfo)
 	if err != nil {

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -75,7 +75,7 @@ type entryTime struct {
 
 type matchPaths struct {
 	epPathClient     string
-	epSize           int64
+	epSizeClient     int64
 	packPathAnnounce string
 }
 
@@ -328,7 +328,7 @@ func (p *processor) processSeasonPack() (int, error) {
 			currentMatch := []matchPaths{
 				{
 					epPathClient:     epPathClient,
-					epSize:           size,
+					epSizeClient:     size,
 					packPathAnnounce: packPathAnnounce,
 				},
 			}
@@ -461,7 +461,7 @@ func (p *processor) parseTorrent() (int, error) {
 		newPackPath := utils.ReplaceParentFolder(match.packPathAnnounce, packNameParsed)
 
 		// TODO: rework this functionality as it currently leads to overwritten hardlinks
-		newPackPath, err = utils.MatchFileNameToSeasonPackNaming(newPackPath, match.epSize, torrentEps)
+		newPackPath, err = utils.MatchEpToSeasonPackEp(newPackPath, match.epSizeClient, torrentEps)
 		if err != nil {
 			p.log.Error().Err(err).Msgf("error matching episode to file in season pack, skipping hardlink: %q", match.epPathClient)
 			hardlinkRespCodes = append(hardlinkRespCodes, StatusFailedHardlink)

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -465,14 +465,14 @@ func (p *processor) parseTorrent() (int, error) {
 		// TODO: rework this functionality as it currently leads to overwritten hardlinks
 		for _, torrentEp := range torrentEps {
 			matchedPath, matchErr = utils.MatchEpToSeasonPackEp(newPackPath, match.epSizeClient, torrentEp)
-			if err != nil {
-				p.log.Debug().Err(err).Msgf("episode did not match: client(%s), torrent(%s)", match.epPathClient, torrentEp.Name)
+			if matchErr != nil {
+				p.log.Debug().Err(matchErr).Msgf("episode did not match: client(%s), torrent(%s)", match.epPathClient, torrentEp.Name)
 				continue
 			}
 			break
 		}
 		if matchErr != nil {
-			p.log.Error().Err(err).Msgf("error matching episode to file in season pack, skipping hardlink: %q", match.epPathClient)
+			p.log.Error().Err(matchErr).Msgf("error matching episode to file in pack, skipping hardlink: %q", match.epPathClient)
 			hardlinkRespCodes = append(hardlinkRespCodes, StatusFailedHardlink)
 			continue
 		}

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -318,7 +318,6 @@ func (p *processor) processSeasonPack() (int, error) {
 				size = f.Size
 				break
 			}
-			p.log.Debug().Msgf("size of episode in client: %d", size)
 
 			epRls := rls.ParseString(child.T.Name)
 			epPathClient := filepath.Join(child.T.SavePath, fileName)
@@ -341,7 +340,7 @@ func (p *processor) processSeasonPack() (int, error) {
 
 			newMatches := append(oldMatches.([]matchPaths), currentMatch...)
 			matchesMap.Store(p.req.Name, newMatches)
-			p.log.Debug().Msgf("matched torrent from client %q: %q %q", clientName, child.T.Name, child.T.Hash)
+			p.log.Debug().Msgf("matched torrent from client: name(%s), size(%d), hash(%s)", child.T.Name, size, child.T.Hash)
 			respCodes = append(respCodes, res)
 			continue
 		}

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -464,7 +464,9 @@ func (p *processor) parseTorrent() (int, error) {
 		// TODO: rework this functionality as it currently leads to overwritten hardlinks
 		newPackPath, err = utils.MatchFileNameToSeasonPackNaming(newPackPath, match.epSize, torrentEps)
 		if err != nil {
-			p.log.Error().Err(err).Msgf("error matching episode to file in season pack: %q", match.epPathClient)
+			p.log.Error().Err(err).Msgf("error matching episode to file in season pack, skipping hardlink: %q", match.epPathClient)
+			hardlinkRespCodes = append(hardlinkRespCodes, StatusFailedHardlink)
+			continue
 		}
 
 		if err = utils.CreateHardlink(match.epPathClient, newPackPath); err != nil {

--- a/internal/utils/formatting.go
+++ b/internal/utils/formatting.go
@@ -54,25 +54,20 @@ func ReplaceParentFolder(path, newFolder string) string {
 	return newPath
 }
 
-func MatchEpToSeasonPackEp(epInClientPath string, epInClientSize int64, torrentEps []torrents.Episode) (string, error) {
+func MatchEpToSeasonPackEp(epInClientPath string, epInClientSize int64, torrentEp torrents.Episode) (string, error) {
 	episodeRls := rls.ParseString(filepath.Base(epInClientPath))
+	torrentEpRls := rls.ParseString(filepath.Base(torrentEp.Name))
 
-	for _, torrentEp := range torrentEps {
-		torrentEpRls := rls.ParseString(filepath.Base(torrentEp.Name))
-
-		err := compareEpisodes(episodeRls, torrentEpRls)
-		if err != nil {
-			continue
-		}
-
-		if epInClientSize != torrentEp.Size {
-			continue
-		}
-
-		return filepath.Join(filepath.Dir(epInClientPath), filepath.Base(torrentEp.Name)), nil
+	err := compareEpisodes(episodeRls, torrentEpRls)
+	if err != nil {
+		return epInClientPath, err
 	}
 
-	return epInClientPath, fmt.Errorf("no matching episode in season pack")
+	if epInClientSize != torrentEp.Size {
+		return epInClientPath, fmt.Errorf("size mismatch")
+	}
+
+	return filepath.Join(filepath.Dir(epInClientPath), filepath.Base(torrentEp.Name)), nil
 }
 
 func compareEpisodes(episodeRls, torrentEpRls rls.Release) error {

--- a/internal/utils/formatting.go
+++ b/internal/utils/formatting.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"seasonpackarr/internal/torrents"
 	"strings"
 
 	"github.com/moistari/rls"
@@ -52,19 +53,20 @@ func ReplaceParentFolder(path, newFolder string) string {
 	return newPath
 }
 
-func MatchFileNameToSeasonPackNaming(episodeInClientPath string, torrentEpisodeNames []string) (string, error) {
-	episodeRls := rls.ParseString(filepath.Base(episodeInClientPath))
+func MatchFileNameToSeasonPackNaming(epInClientPath string, epInClientSize int64, torrentEps []torrents.Episode) (string, error) {
+	episodeRls := rls.ParseString(filepath.Base(epInClientPath))
 
-	for _, packPath := range torrentEpisodeNames {
-		packRls := rls.ParseString(filepath.Base(packPath))
+	for _, torrentEp := range torrentEps {
+		torrentEpRls := rls.ParseString(filepath.Base(torrentEp.Name))
 
-		if (episodeRls.Series == packRls.Series) &&
-			(episodeRls.Episode == packRls.Episode) &&
-			(episodeRls.Resolution == packRls.Resolution) &&
-			(episodeRls.Group == packRls.Group) {
-			return filepath.Join(filepath.Dir(episodeInClientPath), filepath.Base(packPath)), nil
+		if (episodeRls.Series == torrentEpRls.Series) &&
+			(episodeRls.Episode == torrentEpRls.Episode) &&
+			(episodeRls.Resolution == torrentEpRls.Resolution) &&
+			(episodeRls.Group == torrentEpRls.Group) &&
+			(epInClientSize == torrentEp.Size) {
+			return filepath.Join(filepath.Dir(epInClientPath), filepath.Base(torrentEp.Name)), nil
 		}
 	}
 
-	return episodeInClientPath, fmt.Errorf("couldn't find matching episode in season pack, using existing file name")
+	return epInClientPath, fmt.Errorf("couldn't find matching episode in season pack, using existing file name")
 }

--- a/internal/utils/formatting.go
+++ b/internal/utils/formatting.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"seasonpackarr/internal/torrents"
 	"strings"
+
+	"seasonpackarr/internal/torrents"
 
 	"github.com/moistari/rls"
 )

--- a/internal/utils/formatting.go
+++ b/internal/utils/formatting.go
@@ -69,5 +69,5 @@ func MatchFileNameToSeasonPackNaming(epInClientPath string, epInClientSize int64
 		}
 	}
 
-	return epInClientPath, fmt.Errorf("couldn't find matching episode in season pack, using existing file name")
+	return epInClientPath, fmt.Errorf("couldn't find matching episode in season pack")
 }

--- a/internal/utils/formatting_test.go
+++ b/internal/utils/formatting_test.go
@@ -238,7 +238,7 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 	type args struct {
 		epInClientPath string
 		epInClientSize int64
-		torrentEps     []torrents.Episode
+		torrentEp      torrents.Episode
 	}
 	tests := []struct {
 		name    string
@@ -251,15 +251,9 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 			args: args{
 				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 				epInClientSize: 2316560346,
-				torrentEps: []torrents.Episode{
-					{
-						Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2316560346,
-					},
-					{
-						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2278773077,
-					},
+				torrentEp: torrents.Episode{
+					Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+					Size: 2316560346,
 				},
 			},
 			want:    "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
@@ -270,15 +264,9 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 			args: args{
 				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 				epInClientSize: 2316560346,
-				torrentEps: []torrents.Episode{
-					{
-						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2316560346,
-					},
-					{
-						Name: "Series Title 2022 S02E03 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2278773077,
-					},
+				torrentEp: torrents.Episode{
+					Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+					Size: 2316560346,
 				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
@@ -289,15 +277,9 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 			args: args{
 				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 				epInClientSize: 2316560346,
-				torrentEps: []torrents.Episode{
-					{
-						Name: "Series Title 2022 S03E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2316560346,
-					},
-					{
-						Name: "Series Title 2022 S03E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2278773077,
-					},
+				torrentEp: torrents.Episode{
+					Name: "Series Title 2022 S03E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+					Size: 2316560346,
 				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
@@ -308,15 +290,9 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 			args: args{
 				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 				epInClientSize: 2316560346,
-				torrentEps: []torrents.Episode{
-					{
-						Name: "Series Title 2022 S02E01 2160p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2316560346,
-					},
-					{
-						Name: "Series Title 2022 S02E02 2160p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2278773077,
-					},
+				torrentEp: torrents.Episode{
+					Name: "Series Title 2022 S02E01 2160p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+					Size: 2316560346,
 				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
@@ -327,15 +303,9 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 			args: args{
 				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 				epInClientSize: 2316560346,
-				torrentEps: []torrents.Episode{
-					{
-						Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-OtherRlsGrp.mkv",
-						Size: 2316560346,
-					},
-					{
-						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-OtherRlsGrp.mkv",
-						Size: 2278773077,
-					},
+				torrentEp: torrents.Episode{
+					Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-OtherRlsGrp.mkv",
+					Size: 2316560346,
 				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
@@ -346,15 +316,9 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 			args: args{
 				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 				epInClientSize: 2316560346,
-				torrentEps: []torrents.Episode{
-					{
-						Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2278773077,
-					},
-					{
-						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-						Size: 2316560346,
-					},
+				torrentEp: torrents.Episode{
+					Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+					Size: 2278773077,
 				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
@@ -365,7 +329,7 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 			args: args{
 				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 				epInClientSize: 2316560346,
-				torrentEps:     []torrents.Episode{},
+				torrentEp:      torrents.Episode{},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
 			wantErr: assert.Error,
@@ -373,11 +337,11 @@ func Test_MatchEpToSeasonPackEp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MatchEpToSeasonPackEp(tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
-			if !tt.wantErr(t, err, fmt.Sprintf("MatchEpToSeasonPackEp(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)) {
+			got, err := MatchEpToSeasonPackEp(tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEp)
+			if !tt.wantErr(t, err, fmt.Sprintf("MatchEpToSeasonPackEp(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEp)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "MatchEpToSeasonPackEp(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
+			assert.Equalf(t, tt.want, got, "MatchEpToSeasonPackEp(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEp)
 		})
 	}
 }

--- a/internal/utils/formatting_test.go
+++ b/internal/utils/formatting_test.go
@@ -234,7 +234,7 @@ func Test_ReplaceParentFolder(t *testing.T) {
 	}
 }
 
-func TestMatchFileNameToSeasonPackNaming1(t *testing.T) {
+func Test_MatchEpToSeasonPackEp(t *testing.T) {
 	type args struct {
 		epInClientPath string
 		epInClientSize int64
@@ -373,11 +373,11 @@ func TestMatchFileNameToSeasonPackNaming1(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MatchFileNameToSeasonPackNaming(tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
-			if !tt.wantErr(t, err, fmt.Sprintf("MatchFileNameToSeasonPackNaming(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)) {
+			got, err := MatchEpToSeasonPackEp(tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
+			if !tt.wantErr(t, err, fmt.Sprintf("MatchEpToSeasonPackEp(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "MatchFileNameToSeasonPackNaming(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
+			assert.Equalf(t, tt.want, got, "MatchEpToSeasonPackEp(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
 		})
 	}
 }

--- a/internal/utils/formatting_test.go
+++ b/internal/utils/formatting_test.go
@@ -4,7 +4,10 @@
 package utils
 
 import (
+	"fmt"
 	"testing"
+
+	"seasonpackarr/internal/torrents"
 
 	"github.com/moistari/rls"
 	"github.com/stretchr/testify/assert"
@@ -231,81 +234,150 @@ func Test_ReplaceParentFolder(t *testing.T) {
 	}
 }
 
-func TestMatchFileNameToSeasonPackNaming(t *testing.T) {
+func TestMatchFileNameToSeasonPackNaming1(t *testing.T) {
+	type args struct {
+		epInClientPath string
+		epInClientSize int64
+		torrentEps     []torrents.Episode
+	}
 	tests := []struct {
-		name         string
-		epPathClient string
-		torrentEps   []string
-		want         string
-		wantErr      bool
+		name    string
+		args    args
+		want    string
+		wantErr assert.ErrorAssertionFunc
 	}{
 		{
-			name:         "found_match",
-			epPathClient: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			torrentEps: []string{
-				"Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-				"Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+			name: "found_match",
+			args: args{
+				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+				epInClientSize: 2316560346,
+				torrentEps: []torrents.Episode{
+					{
+						Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2316560346,
+					},
+					{
+						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2278773077,
+					},
+				},
 			},
 			want:    "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			wantErr: false,
+			wantErr: assert.NoError,
 		},
 		{
-			name:         "wrong_episode",
-			epPathClient: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			torrentEps: []string{
-				"Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-				"Series Title 2022 S02E03 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+			name: "wrong_episode",
+			args: args{
+				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+				epInClientSize: 2316560346,
+				torrentEps: []torrents.Episode{
+					{
+						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2316560346,
+					},
+					{
+						Name: "Series Title 2022 S02E03 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2278773077,
+					},
+				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
-			name:         "found_no_match",
-			epPathClient: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			torrentEps:   []string{},
-			want:         "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			wantErr:      true,
-		},
-		{
-			name:         "wrong_season",
-			epPathClient: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			torrentEps: []string{
-				"Series Title 2022 S03E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-				"Series Title 2022 S03E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+			name: "wrong_season",
+			args: args{
+				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+				epInClientSize: 2316560346,
+				torrentEps: []torrents.Episode{
+					{
+						Name: "Series Title 2022 S03E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2316560346,
+					},
+					{
+						Name: "Series Title 2022 S03E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2278773077,
+					},
+				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
-			name:         "wrong_resolution",
-			epPathClient: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			torrentEps: []string{
-				"Series Title 2022 S02E01 720p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-				"Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+			name: "wrong_resolution",
+			args: args{
+				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+				epInClientSize: 2316560346,
+				torrentEps: []torrents.Episode{
+					{
+						Name: "Series Title 2022 S02E01 2160p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2316560346,
+					},
+					{
+						Name: "Series Title 2022 S02E02 2160p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2278773077,
+					},
+				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			wantErr: true,
+			wantErr: assert.Error,
 		},
 		{
-			name:         "wrong_rlsgrp",
-			epPathClient: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			torrentEps: []string{
-				"Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp2.mkv",
-				"Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+			name: "wrong_rlsgrp",
+			args: args{
+				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+				epInClientSize: 2316560346,
+				torrentEps: []torrents.Episode{
+					{
+						Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-OtherRlsGrp.mkv",
+						Size: 2316560346,
+					},
+					{
+						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-OtherRlsGrp.mkv",
+						Size: 2278773077,
+					},
+				},
 			},
 			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
-			wantErr: true,
+			wantErr: assert.Error,
+		},
+		{
+			name: "wrong_size",
+			args: args{
+				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+				epInClientSize: 2316560346,
+				torrentEps: []torrents.Episode{
+					{
+						Name: "Series Title 2022 S02E01 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2278773077,
+					},
+					{
+						Name: "Series Title 2022 S02E02 1080p Test ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+						Size: 2316560346,
+					},
+				},
+			},
+			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+			wantErr: assert.Error,
+		},
+		{
+			name: "found_no_match",
+			args: args{
+				epInClientPath: "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+				epInClientSize: 2316560346,
+				torrentEps:     []torrents.Episode{},
+			},
+			want:    "Series Title 2022 S02E01 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-RlsGrp.mkv",
+			wantErr: assert.Error,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MatchFileNameToSeasonPackNaming(tt.epPathClient, tt.torrentEps)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+			got, err := MatchFileNameToSeasonPackNaming(tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
+			if !tt.wantErr(t, err, fmt.Sprintf("MatchFileNameToSeasonPackNaming(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)) {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "MatchFileNameToSeasonPackNaming(%v, %v)", tt.epPathClient, tt.torrentEps)
+			assert.Equalf(t, tt.want, got, "MatchFileNameToSeasonPackNaming(%v, %v, %v)", tt.args.epInClientPath, tt.args.epInClientSize, tt.args.torrentEps)
 		})
 	}
 }


### PR DESCRIPTION
Changes matching filenames to season pack filenames to be stricter by introducing a size check. Should prevent borking hardlinked episodes in the process.