### PR TITLE
feat(cli): add torrent file support for parse command

### DIFF
--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -17,10 +17,12 @@ var packCmd = &cobra.Command{
 	Short:   "Test the pack api endpoint for a specified release",
 	Example: `  seasonpackarr test pack --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(rlsName) == 0 {
-			fmt.Println("The release name can't be empty")
+		if len(args) == 0 {
+			fmt.Println("Please provide a release name")
 			return
 		}
+
+		rlsName = args[0]
 
 		body, err := payload.CompilePackPayload(rlsName, clientName)
 		if err != nil {

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -11,12 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// packCmd represents the test command
+// packCmd represents the pack command
 var packCmd = &cobra.Command{
 	Use:     "pack",
 	Short:   "Test the pack api endpoint for a specified release",
 	Example: `  seasonpackarr test pack --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(rlsName) == 0 {
+			fmt.Println("The release name can't be empty")
+			return
+		}
+
 		body, err := payload.CompilePackPayload(rlsName, clientName)
 		if err != nil {
 			fmt.Println(err.Error())

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -15,7 +15,7 @@ import (
 var packCmd = &cobra.Command{
 	Use:     "pack",
 	Short:   "Test the pack api endpoint for a specified release",
-	Example: `  seasonpackarr test pack --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
+	Example: `  seasonpackarr test pack “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			fmt.Println("Please provide a release name")

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"seasonpackarr/internal/payload"
 	"seasonpackarr/internal/torrents"
@@ -20,19 +22,23 @@ import (
 var parseCmd = &cobra.Command{
 	Use:   "parse",
 	Short: "Test the parse api endpoint for a specified release",
-	Example: `  seasonpackarr test parse --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"
-  seasonpackarr test parse --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --torrent “Series.S01.1080p.WEB-DL.H.264-RlsGrp.torrent” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
+	Example: `  seasonpackarr test parse “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"
+  seasonpackarr test parse “/path/to/Series.S01.1080p.WEB-DL.H.264-RlsGrp.torrent” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var torrentBytes []byte
 		var body io.Reader
 		var err error
 
-		if len(rlsName) == 0 {
-			fmt.Println("The release name can't be empty")
+		if len(args) == 0 {
+			fmt.Println("Please provide either a release name or a .torrent file to parse")
 			return
 		}
 
-		if !cmd.Flags().Changed("torrent") {
+		torrentFile = args[0]
+		// trim .torrent extension and remove full path for rlsName
+		rlsName = strings.TrimSuffix(filepath.Base(torrentFile), ".torrent")
+
+		if filepath.Ext(torrentFile) != ".torrent" {
 			torrentBytes, err = torrents.TorrentFromRls(rlsName, 5)
 			if err != nil {
 				fmt.Println(err.Error())

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -5,26 +5,58 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"io/fs"
+	"os"
 
 	"seasonpackarr/internal/payload"
 	"seasonpackarr/internal/torrents"
+	"seasonpackarr/pkg/errors"
 
 	"github.com/spf13/cobra"
 )
 
-// parseCmd represents the test command
+// parseCmd represents the parse command
 var parseCmd = &cobra.Command{
-	Use:     "parse",
-	Short:   "Test the parse api endpoint for a specified release",
-	Example: `  seasonpackarr test parse --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
+	Use:   "parse",
+	Short: "Test the parse api endpoint for a specified release",
+	Example: `  seasonpackarr test parse --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"
+  seasonpackarr test parse --rls “Series.S01.1080p.WEB-DL.H.264-RlsGrp” --torrent “Series.S01.1080p.WEB-DL.H.264-RlsGrp.torrent” --client "default" --host "127.0.0.1" --port 42069 --api "your-api-key"`,
 	Run: func(cmd *cobra.Command, args []string) {
-		torrentBytes, err := torrents.TorrentFromRls(rlsName, 5)
-		if err != nil {
-			fmt.Println(err.Error())
+		var torrentBytes []byte
+		var body io.Reader
+		var err error
+
+		if len(rlsName) == 0 {
+			fmt.Println("The release name can't be empty")
 			return
 		}
 
-		body, err := payload.CompileParsePayload(rlsName, torrentBytes, clientName)
+		if !cmd.Flags().Changed("torrent") {
+			torrentBytes, err = torrents.TorrentFromRls(rlsName, 5)
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+		} else {
+			if len(torrentFile) == 0 {
+				fmt.Println("The path of the torrent file can't be empty")
+				return
+			}
+
+			if _, err := os.Stat(torrentFile); errors.Is(err, fs.ErrNotExist) {
+				fmt.Println("The specified torrent file doesn't exist", err.Error())
+				return
+			}
+
+			torrentBytes, err = os.ReadFile(torrentFile)
+			if err != nil {
+				fmt.Println(err.Error())
+				return
+			}
+		}
+
+		body, err = payload.CompileParsePayload(rlsName, torrentBytes, clientName)
 		if err != nil {
 			fmt.Println(err.Error())
 			return

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,13 +41,6 @@ func init() {
 	testCmd.PersistentFlags().IntVarP(&port, "port", "p", 42069, "port used by seasonpackarr")
 	testCmd.PersistentFlags().StringVarP(&apiKey, "api", "a", "", "api key used by seasonpackarr")
 
-	testCmd.PersistentFlags().StringVarP(&rlsName, "rls", "r", "", "name of the release you want to test")
-	parseCmd.Flags().StringVarP(&torrentFile, "torrent", "t", "", "path to the torrent file you want to test")
-
-	_ = testCmd.MarkPersistentFlagRequired("rls")
-
-	_ = parseCmd.MarkFlagFilename("torrent", ".torrent")
-
 	rootCmd.AddCommand(genTokenCmd, startCmd, testCmd, versionCmd)
 	testCmd.AddCommand(packCmd, parseCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,12 +10,13 @@ import (
 )
 
 var (
-	configPath string
-	rlsName    string
-	clientName string
-	host       string
-	port       int
-	apiKey     string
+	configPath  string
+	rlsName     string
+	torrentFile string
+	clientName  string
+	host        string
+	port        int
+	apiKey      string
 )
 
 var rootCmd = &cobra.Command{
@@ -33,17 +34,21 @@ For more information and examples, visit https://github.com/nuxencs/seasonpackar
 }
 
 func init() {
-	startCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to configuration directory")
+	startCmd.Flags().StringVarP(&configPath, "config", "c", "", "path to the configuration directory")
 
-	testCmd.PersistentFlags().StringVarP(&rlsName, "rls", "r", "", "name of the release you want to test")
 	testCmd.PersistentFlags().StringVarP(&clientName, "client", "n", "", "name of the client you want to test")
 	testCmd.PersistentFlags().StringVarP(&host, "host", "i", "127.0.0.1", "host used by seasonpackarr")
 	testCmd.PersistentFlags().IntVarP(&port, "port", "p", 42069, "port used by seasonpackarr")
 	testCmd.PersistentFlags().StringVarP(&apiKey, "api", "a", "", "api key used by seasonpackarr")
+
+	testCmd.PersistentFlags().StringVarP(&rlsName, "rls", "r", "", "name of the release you want to test")
+	parseCmd.Flags().StringVarP(&torrentFile, "torrent", "t", "", "path to the torrent file you want to test")
+
 	_ = testCmd.MarkPersistentFlagRequired("rls")
 
-	rootCmd.AddCommand(genTokenCmd, startCmd, testCmd, versionCmd)
+	_ = parseCmd.MarkFlagFilename("torrent", ".torrent")
 
+	rootCmd.AddCommand(genTokenCmd, startCmd, testCmd, versionCmd)
 	testCmd.AddCommand(packCmd, parseCmd)
 }
 


### PR DESCRIPTION
This adds support for .torrent files for the `parse` testing command. This will read the bytes of the .torrent file and test seasonpackarr with the actual data. This should make testing real examples a lot easier.