### PR TITLE
refactor(processor): replace sync.Map with xsync.MapOf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/moistari/rls v0.5.12
 	github.com/mrobinsn/go-tvmaze v1.2.1
 	github.com/pkg/errors v0.9.1
+	github.com/puzpuzpuz/xsync/v3 v3.4.0
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/puzpuzpuz/xsync/v3 v3.4.0 h1:DuVBAdXuGFHv8adVXjWWZ63pJq+NRXOWVXlKDBZ+mJ4=
+github.com/puzpuzpuz/xsync/v3 v3.4.0/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -409,7 +409,7 @@ func (c *AppConfig) load(configPath string) {
 
 	// read config
 	if err := viper.ReadInConfig(); err != nil {
-		log.Printf("config read error: %q", err)
+		log.Fatalf("config read error: %q", err)
 	}
 
 	if err := viper.Unmarshal(c.Config); err != nil {

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -435,7 +435,7 @@ func (p *processor) parseTorrent() (int, error) {
 		return c.Str("release", p.req.Name).Str("clientname", clientName)
 	})
 
-	client, ok := p.cfg.Config.Clients[clientName]
+	clientCfg, ok := p.cfg.Config.Clients[clientName]
 	if !ok {
 		return domain.StatusClientNotFound, fmt.Errorf("client not found in config")
 	}
@@ -480,7 +480,7 @@ func (p *processor) parseTorrent() (int, error) {
 	var matchErr error
 	var targetEpPath string
 
-	targetPackDir := filepath.Join(client.PreImportPath, parsedPackName)
+	targetPackDir := filepath.Join(clientCfg.PreImportPath, parsedPackName)
 
 	for _, match := range matches {
 		for _, torrentEp := range torrentEps {


### PR DESCRIPTION
Replace the standard library `sync.Map` with `xsync.MapOf` which performs much better and is a lot easier to use.
Also use the client name as the key for the `clientMap` and `torrentMap`, because it is already a unique key.