### PR TITLE
refactor: smaller optimizations

### DIFF
--- a/internal/torrents/decode.go
+++ b/internal/torrents/decode.go
@@ -10,7 +10,7 @@ import (
 	"unicode"
 )
 
-func DecodeTorrentDataRawBytes(torrentBytes []byte) ([]byte, error) {
+func DecodeTorrentBytes(torrentBytes []byte) ([]byte, error) {
 	var tb []byte
 	var err error
 

--- a/internal/utils/formatting.go
+++ b/internal/utils/formatting.go
@@ -60,7 +60,7 @@ func MatchEpToSeasonPackEp(clientEpPath string, clientEpSize int64, torrentEpPat
 
 func compareEpisodes(episodeRls, torrentEpRls rls.Release) error {
 	if episodeRls.Series != torrentEpRls.Series {
-		return fmt.Errorf("series mismatch")
+		return fmt.Errorf("season mismatch")
 	}
 
 	if episodeRls.Episode != torrentEpRls.Episode {


### PR DESCRIPTION
This should bring a lot of minor performance improvements by using maps instead of slices to avoid deduplication. This also preallocates memory for new slices when possible and makes the code a bit more readable.