### PR TITLE
feat(config): optionally simplify WEB-DL

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,6 +165,13 @@ fuzzyMatching:
   #
   simplifyHdrCompare: false
 
+  # Simplify WEB Compare
+  # Toggle simplification of WEB-DL for comparing, e.g. WEB-DL will be treated the same as WEB
+  #
+  # Default: false
+  #
+  simplifyWebCompare: false
+
 # Metadata
 # Here you can provide credentials for additional metadata providers
 #
@@ -356,6 +363,7 @@ func (c *AppConfig) defaults() {
 	c.Config.FuzzyMatching = domain.FuzzyMatching{
 		SkipRepackCompare:  false,
 		SimplifyHdrCompare: false,
+		SimplifyWebCompare: false,
 	}
 	c.Config.Metadata = domain.Metadata{
 		TVDBAPIKey: "",
@@ -467,6 +475,10 @@ func (c *AppConfig) loadFromEnv() {
 				case prefix + "FUZZY_MATCHING_SIMPLIFY_HDR_COMPARE":
 					if b, err := strconv.ParseBool(envValue); err == nil {
 						c.Config.FuzzyMatching.SimplifyHdrCompare = b
+					}
+				case prefix + "FUZZY_MATCHING_SIMPLIFY_WEB_COMPARE":
+					if b, err := strconv.ParseBool(envValue); err == nil {
+						c.Config.FuzzyMatching.SimplifyWebCompare = b
 					}
 
 				// metadata settings
@@ -645,6 +657,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 		foundLineFuzzyMatching      = false
 		foundLineSkipRepackCompare  = false
 		foundLineSimplifyHdrCompare = false
+		foundLineSimplifyWebCompare = false
 		foundLineMetadata           = false
 		foundLineMetadataTVDBAPIKey = false
 		foundLineMetadataTVDBPIN    = false
@@ -689,6 +702,10 @@ func (c *AppConfig) processLines(lines []string) []string {
 		if foundLineFuzzyMatching && !foundLineSimplifyHdrCompare && strings.Contains(line, "simplifyHdrCompare:") {
 			lines[i] = fmt.Sprintf("  simplifyHdrCompare: %t", c.Config.FuzzyMatching.SimplifyHdrCompare)
 			foundLineSimplifyHdrCompare = true
+		}
+		if foundLineFuzzyMatching && !foundLineSimplifyWebCompare && strings.Contains(line, "simplifyWebCompare:") {
+			lines[i] = fmt.Sprintf("  simplifyWebCompare: %t", c.Config.FuzzyMatching.SimplifyWebCompare)
+			foundLineSimplifyWebCompare = true
 		}
 		if !foundLineMetadata && strings.Contains(line, "metadata:") {
 			foundLineMetadata = true
@@ -799,6 +816,14 @@ func (c *AppConfig) processLines(lines []string) []string {
 			lines = append(lines, "  # Default: false")
 			lines = append(lines, "  #")
 			lines = append(lines, fmt.Sprintf("  simplifyHdrCompare: %t\n", c.Config.FuzzyMatching.SimplifyHdrCompare))
+		}
+		if !foundLineSimplifyWebCompare {
+			lines = append(lines, "  # Simplify WEB Compare")
+			lines = append(lines, "  # Toggle simplification of WEB-DL for comparing, e.g. WEB-DL will be treated the same as WEB")
+			lines = append(lines, "  #")
+			lines = append(lines, "  # Default: false")
+			lines = append(lines, "  #")
+			lines = append(lines, fmt.Sprintf("  simplifyWebCompare: %t\n", c.Config.FuzzyMatching.SimplifyWebCompare))
 		}
 	}
 

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -15,6 +15,7 @@ type Client struct {
 type FuzzyMatching struct {
 	SkipRepackCompare  bool `yaml:"skipRepackCompare"`
 	SimplifyHdrCompare bool `yaml:"simplifyHdrCompare"`
+	SimplifyWebCompare bool `yaml:"simplifyWebCompare"`
 }
 
 type Notifications struct {

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -31,6 +31,12 @@ func compare(requestRls, clientRls rls.Release, fuzzyMatching domain.FuzzyMatchi
 		}
 	}
 
+	// normalize WEB-DL down to plain WEB when simplifyWebCompare is enabled
+	if fuzzyMatching.SimplifyWebCompare {
+		requestRls.Source = simplifyWEB(requestRls.Source)
+		clientRls.Source = simplifyWEB(clientRls.Source)
+	}
+
 	if requestRls.Source != clientRls.Source {
 		return domain.CompareInfo{
 			StatusCode:   domain.StatusSourceMismatch,
@@ -167,4 +173,12 @@ func IsValidEpisodeFile(torrentFileName string) bool {
 	}
 
 	return true
+}
+
+func simplifyWEB(source string) string {
+	if source == "WEB-DL" {
+		return "WEB"
+	}
+
+	return source
 }

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -243,3 +243,48 @@ func Test_IsValidEpisodeFile(t *testing.T) {
 		})
 	}
 }
+
+func Test_SimplifyWEB(t *testing.T) {
+	type args struct {
+		source string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "web-dl",
+			args: args{
+				source: "WEB-DL",
+			},
+			want: "WEB",
+		},
+		{
+			name: "webrip",
+			args: args{
+				source: "WEBRiP",
+			},
+			want: "WEBRiP",
+		},
+		{
+			name: "bluray",
+			args: args{
+				source: "BluRay",
+			},
+			want: "BluRay",
+		},
+		{
+			name: "empty",
+			args: args{
+				source: "",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, simplifyWEB(tt.args.source), "simplifyWEB(%v)", tt.args.source)
+		})
+	}
+}


### PR DESCRIPTION
Give the option to simplify `WEB-DL` down to `WEB` as some trackers only use `WEB`.

Resolves #204 