### PR TITLE
feat(config): optionally ignore year when comparing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -143,6 +143,13 @@ fuzzyMatching:
   #
   simplifyWebCompare: false
 
+  # Skip Year Compare
+  # Toggle comparing of the year of a release, e.g. a release without a year will be treated the same as a release with a year
+  #
+  # Default: false
+  #
+  skipYearCompare: false
+
 # Metadata
 # Here you can provide credentials for additional metadata providers
 #

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -172,6 +172,13 @@ fuzzyMatching:
   #
   simplifyWebCompare: false
 
+  # Skip Year Compare
+  # Toggle comparing of the year of a release, e.g. a release without a year will be treated the same as a release with a year
+  #
+  # Default: false
+  #
+  skipYearCompare: false
+
 # Metadata
 # Here you can provide credentials for additional metadata providers
 #
@@ -647,24 +654,30 @@ func (c *AppConfig) UpdateConfig() error {
 }
 
 func (c *AppConfig) processLines(lines []string) []string {
-	// keep track of not found values to append at bottom
+	// keep track of not found values to append at the bottom
 	var (
-		foundLineLogLevel           = false
-		foundLineLogPath            = false
+		foundLineLogLevel = false
+		foundLineLogPath  = false
+
 		foundLineSmartMode          = false
 		foundLineSmartModeThreshold = false
 		foundLineParseTorrentFile   = false
+
 		foundLineFuzzyMatching      = false
 		foundLineSkipRepackCompare  = false
 		foundLineSimplifyHdrCompare = false
 		foundLineSimplifyWebCompare = false
+		foundLineSkipYearCompare    = false
+
 		foundLineMetadata           = false
 		foundLineMetadataTVDBAPIKey = false
 		foundLineMetadataTVDBPIN    = false
-		foundLineAPIToken           = false
-		foundLineNotifications      = false
-		foundLineNotificationLevel  = false
-		foundLineDiscord            = false
+
+		foundLineAPIToken = false
+
+		foundLineNotifications     = false
+		foundLineNotificationLevel = false
+		foundLineDiscord           = false
 	)
 
 	for i, line := range lines {
@@ -680,6 +693,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 			}
 			foundLineLogPath = true
 		}
+
 		if !foundLineSmartMode && strings.Contains(line, "smartMode:") {
 			lines[i] = fmt.Sprintf("smartMode: %t", c.Config.SmartMode)
 			foundLineSmartMode = true
@@ -692,6 +706,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 			lines[i] = fmt.Sprintf("parseTorrentFile: %t", c.Config.ParseTorrentFile)
 			foundLineParseTorrentFile = true
 		}
+
 		if !foundLineFuzzyMatching && strings.Contains(line, "fuzzyMatching:") {
 			foundLineFuzzyMatching = true
 		}
@@ -707,6 +722,11 @@ func (c *AppConfig) processLines(lines []string) []string {
 			lines[i] = fmt.Sprintf("  simplifyWebCompare: %t", c.Config.FuzzyMatching.SimplifyWebCompare)
 			foundLineSimplifyWebCompare = true
 		}
+		if foundLineFuzzyMatching && !foundLineSkipYearCompare && strings.Contains(line, "skipYearCompare:") {
+			lines[i] = fmt.Sprintf("  skipYearCompare: %t", c.Config.FuzzyMatching.SkipYearCompare)
+			foundLineSkipYearCompare = true
+		}
+
 		if !foundLineMetadata && strings.Contains(line, "metadata:") {
 			foundLineMetadata = true
 		}
@@ -718,6 +738,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 			lines[i] = fmt.Sprintf("  tvdbPIN: \"%s\"", c.Config.Metadata.TVDBPIN)
 			foundLineMetadataTVDBPIN = true
 		}
+
 		if !foundLineAPIToken && strings.Contains(line, "apiToken:") {
 			if c.Config.APIToken == "" {
 				lines[i] = "# apiToken: \"\""
@@ -726,6 +747,7 @@ func (c *AppConfig) processLines(lines []string) []string {
 			}
 			foundLineAPIToken = true
 		}
+
 		if !foundLineNotifications && strings.Contains(line, "notifications:") {
 			foundLineNotifications = true
 		}
@@ -824,6 +846,14 @@ func (c *AppConfig) processLines(lines []string) []string {
 			lines = append(lines, "  # Default: false")
 			lines = append(lines, "  #")
 			lines = append(lines, fmt.Sprintf("  simplifyWebCompare: %t\n", c.Config.FuzzyMatching.SimplifyWebCompare))
+		}
+		if !foundLineSkipYearCompare {
+			lines = append(lines, "  # Skip Year Compare")
+			lines = append(lines, "  # Toggle comparing of the year of a release, e.g. a release without a year will be treated the same as a release with a year")
+			lines = append(lines, "  #")
+			lines = append(lines, "  # Default: false")
+			lines = append(lines, "  #")
+			lines = append(lines, fmt.Sprintf("  skipYearCompare: %t\n", c.Config.FuzzyMatching.SkipRepackCompare))
 		}
 	}
 

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -16,6 +16,7 @@ type FuzzyMatching struct {
 	SkipRepackCompare  bool `yaml:"skipRepackCompare"`
 	SimplifyHdrCompare bool `yaml:"simplifyHdrCompare"`
 	SimplifyWebCompare bool `yaml:"simplifyWebCompare"`
+	SkipYearCompare    bool `yaml:"skipYearCompare"`
 }
 
 type Notifications struct {

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/nuxencs/seasonpackarr/internal/domain"
+
 	"github.com/moistari/rls"
 )
 
@@ -20,10 +22,12 @@ var (
 	dots    = regexp.MustCompile(`(?i)\.+`)
 )
 
-func ComparableTitle(r rls.Release) string {
-	s := fmt.Sprintf("%s%d%d", rls.MustNormalize(r.Title), r.Year, r.Series)
+func ComparableTitle(r rls.Release, fuzzyMatching domain.FuzzyMatching) string {
+	if fuzzyMatching.SkipYearCompare {
+		return fmt.Sprintf("%s%d", rls.MustNormalize(r.Title), r.Series)
+	}
 
-	return s
+	return fmt.Sprintf("%s%d%d", rls.MustNormalize(r.Title), r.Year, r.Series)
 }
 
 func CleanAnnounceTitle(release rls.Release) string {

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -6,15 +6,18 @@ package format
 import (
 	"testing"
 
+	"github.com/nuxencs/seasonpackarr/internal/domain"
+
 	"github.com/moistari/rls"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_ComparableTitle(t *testing.T) {
 	tests := []struct {
-		name     string
-		packName string
-		want     string
+		name          string
+		packName      string
+		fuzzyMatching domain.FuzzyMatching
+		want          string
 	}{
 		{
 			name:     "pack_1",
@@ -86,11 +89,23 @@ func Test_ComparableTitle(t *testing.T) {
 			packName: "The Continental 2023 S01 2160p PCOK WEB-DL DDP5.1 Atmos HDR DV H.265-FLUX",
 			want:     "the continental20231",
 		},
+		{
+			name:          "pack_skip_year",
+			packName:      "The Continental 2023 S01 2160p PCOK WEB-DL DDP5.1 Atmos HDR DV H.265-FLUX",
+			fuzzyMatching: domain.FuzzyMatching{SkipYearCompare: true},
+			want:          "the continental1",
+		},
+		{
+			name:          "pack_skip_empty_year",
+			packName:      "The Continental S01 2160p PCOK WEB-DL DDP5.1 Atmos HDR DV H.265-FLUX",
+			fuzzyMatching: domain.FuzzyMatching{SkipYearCompare: true},
+			want:          "the continental1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := rls.ParseString(tt.packName)
-			assert.Equalf(t, tt.want, ComparableTitle(r), "ComparableTitle(%s)", tt.packName)
+			assert.Equalf(t, tt.want, ComparableTitle(r, tt.fuzzyMatching), "ComparableTitle(%s)", tt.packName)
 		})
 	}
 }

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -145,7 +145,7 @@ func (p *processor) getAllTorrents(clientName string) (map[string][]entry, error
 			entries.rlsMap[t.Name] = r
 		}
 
-		comparableTitle := format.ComparableTitle(r)
+		comparableTitle := format.ComparableTitle(r, p.cfg.Config.FuzzyMatching)
 		entries.entriesMap[comparableTitle] = append(entries.entriesMap[comparableTitle], entry{torrent: t, release: r})
 	}
 
@@ -265,7 +265,7 @@ func (p *processor) processSeasonPack() (domain.StatusCode, error) {
 	}
 
 	requestRls := rls.ParseString(p.req.Name)
-	filteredEntries, ok := entries[format.ComparableTitle(requestRls)]
+	filteredEntries, ok := entries[format.ComparableTitle(requestRls, p.cfg.Config.FuzzyMatching)]
 	if !ok {
 		return domain.StatusNoMatches, domain.StatusNoMatches.Error()
 	}

--- a/schemas/config-schema.json
+++ b/schemas/config-schema.json
@@ -123,6 +123,10 @@
         "simplifyWebCompare": {
           "type": "boolean",
           "default": false
+        },
+        "skipYearCompare" : {
+          "type": "boolean",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
Give the option to ignore the year of a show when checking if any episodes in the torrent match the announced season pack.

Resolves #209 