### PR TITLE
fix(http): fix URL construction bugs in buildHost

### DIFF
--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -6,8 +6,11 @@ package http
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -518,19 +521,19 @@ func buildHost(client *domain.Client) (string, error) {
 		return "", errors.New("host is required")
 	}
 
-	parsedURL, err := url.Parse(client.Host)
+	host := client.Host
+	if !strings.Contains(host, "://") {
+		host = "http://" + host
+	}
+
+	parsedURL, err := url.Parse(host)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse host")
 	}
 
-	host := client.Host
 	if client.Port != 0 {
-		host = fmt.Sprintf("%s:%d", client.Host, client.Port)
+		parsedURL.Host = net.JoinHostPort(parsedURL.Hostname(), strconv.Itoa(client.Port))
 	}
 
-	if parsedURL.Scheme == "" {
-		host = fmt.Sprintf("http://%s", host)
-	}
-
-	return host, nil
+	return parsedURL.String(), nil
 }

--- a/internal/http/processor_test.go
+++ b/internal/http/processor_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package http
+
+import (
+	"testing"
+
+	"github.com/nuxencs/seasonpackarr/internal/domain"
+)
+
+func TestBuildHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		client  *domain.Client
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "empty host",
+			client:  &domain.Client{Host: ""},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:   "bare hostname",
+			client: &domain.Client{Host: "localhost"},
+			want:   "http://localhost",
+		},
+		{
+			name:   "bare hostname with port field",
+			client: &domain.Client{Host: "localhost", Port: 8080},
+			want:   "http://localhost:8080",
+		},
+		{
+			name:   "hostname with http scheme",
+			client: &domain.Client{Host: "http://localhost"},
+			want:   "http://localhost",
+		},
+		{
+			name:   "hostname with https scheme",
+			client: &domain.Client{Host: "https://myhost"},
+			want:   "https://myhost",
+		},
+		{
+			name:   "hostname with scheme and port field",
+			client: &domain.Client{Host: "https://myhost", Port: 8080},
+			want:   "https://myhost:8080",
+		},
+		{
+			name:   "hostname with existing port and port field override",
+			client: &domain.Client{Host: "http://localhost:9090", Port: 8080},
+			want:   "http://localhost:8080",
+		},
+		{
+			name:   "schemeless host:port string",
+			client: &domain.Client{Host: "localhost:9090"},
+			want:   "http://localhost:9090",
+		},
+		{
+			name:   "schemeless host:port with port field override",
+			client: &domain.Client{Host: "localhost:9090", Port: 8080},
+			want:   "http://localhost:8080",
+		},
+		{
+			name:   "ip address",
+			client: &domain.Client{Host: "192.168.1.1"},
+			want:   "http://192.168.1.1",
+		},
+		{
+			name:   "ip address with port field",
+			client: &domain.Client{Host: "192.168.1.1", Port: 8080},
+			want:   "http://192.168.1.1:8080",
+		},
+		{
+			name:   "scheme with ip and port in host",
+			client: &domain.Client{Host: "http://192.168.1.1:9090"},
+			want:   "http://192.168.1.1:9090",
+		},
+		{
+			name:   "zero port field does not append port",
+			client: &domain.Client{Host: "http://localhost", Port: 0},
+			want:   "http://localhost",
+		},
+		{
+			name:   "host with path preserved",
+			client: &domain.Client{Host: "http://localhost:8080/123456abcdef"},
+			want:   "http://localhost:8080/123456abcdef",
+		},
+		{
+			name:   "host with path and port field override",
+			client: &domain.Client{Host: "http://localhost:8080/123456abcdef", Port: 9090},
+			want:   "http://localhost:9090/123456abcdef",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := buildHost(tt.client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildHost() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("buildHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Rewrite buildHost to properly use `url.Parse` for URL construction instead of fragile string concatenation. Fixes double-port when host already contains a port, schemeless host:port being misdetected as having a scheme, and port field not overriding existing port in host string.