### PR TITLE
fix(metadata): find shows with long or localized titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ go.work
 .idea/
 .vscode/
 dist/
+
+# Environment variables
+.env

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,6 +48,7 @@
 - Implemented in `internal/metadata/`
 - Providers: TVDB and TVMaze
 - Purpose: estimate total episodes for smart-mode decisions and cross-check provider disagreement
+- Lookup strategy: search with the parsed release title first, then retry with progressively shortened title variants (guarded by name/alias/translation matching), because provider searches often miss long or localized titles
 
 ### File Operations
 
@@ -89,6 +90,8 @@ Current explicit test coverage exists in:
 
 - `internal/release/release_test.go`
 - `internal/format/format_test.go`
+- `internal/metadata/titles_test.go`
+- `internal/metadata/tvdb_test.go` (requires `TVDB_API_KEY` env var, skipped otherwise)
 - `internal/metadata/tvmaze_test.go`
 - `internal/slices/slices_test.go`
 

--- a/internal/metadata/titles.go
+++ b/internal/metadata/titles.go
@@ -36,7 +36,9 @@ func shortenedTitles(normTitle string) []string {
 
 // matchesTitle reports whether any of the candidate names matches the normalized
 // release title, either exactly or as its leading words. This guards shortened
-// title searches against matching an unrelated show.
+// title searches against matching an unrelated show. A prefix match requires at
+// least two candidate words; a single leading word is too generic to vouch for
+// the show.
 func matchesTitle(normTitle string, candidates ...string) bool {
 	for _, candidate := range candidates {
 		normCandidate := rls.MustNormalize(candidate)
@@ -44,7 +46,11 @@ func matchesTitle(normTitle string, candidates ...string) bool {
 			continue
 		}
 
-		if normCandidate == normTitle || strings.HasPrefix(normTitle, normCandidate+" ") {
+		if normCandidate == normTitle {
+			return true
+		}
+
+		if strings.Contains(normCandidate, " ") && strings.HasPrefix(normTitle, normCandidate+" ") {
 			return true
 		}
 	}

--- a/internal/metadata/titles.go
+++ b/internal/metadata/titles.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package metadata
+
+import (
+	"strings"
+
+	"github.com/moistari/rls"
+)
+
+// maxVariantWords caps the longest shortened title variant. Provider searches
+// were only ever observed to fail for titles of 7 or more words, so longer
+// variants add API calls without improving the chance of a match. Together with
+// the two-word minimum this bounds the fallback at 5 extra calls per provider,
+// keeping bursts well below the TVMaze rate limit of 20 calls per 10 seconds.
+const maxVariantWords = 6
+
+// shortenedTitles returns progressively shortened variants of a normalized title,
+// dropping one trailing word at a time down to a minimum of two words. Release
+// names sometimes carry a localized subtitle after the actual show title, which
+// makes provider searches come up empty; searching with shortened variants
+// converges back to the actual show title.
+func shortenedTitles(normTitle string) []string {
+	words := strings.Fields(normTitle)
+
+	longestVariant := min(len(words)-1, maxVariantWords)
+
+	var titles []string
+	for i := longestVariant; i >= 2; i-- {
+		titles = append(titles, strings.Join(words[:i], " "))
+	}
+
+	return titles
+}
+
+// matchesTitle reports whether any of the candidate names matches the normalized
+// release title, either exactly or as its leading words. This guards shortened
+// title searches against matching an unrelated show.
+func matchesTitle(normTitle string, candidates ...string) bool {
+	for _, candidate := range candidates {
+		normCandidate := rls.MustNormalize(candidate)
+		if normCandidate == "" {
+			continue
+		}
+
+		if normCandidate == normTitle || strings.HasPrefix(normTitle, normCandidate+" ") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/metadata/titles_test.go
+++ b/internal/metadata/titles_test.go
@@ -92,6 +92,18 @@ func Test_MatchesTitle(t *testing.T) {
 			want:       false,
 		},
 		{
+			name:       "single_word_prefix_does_not_match",
+			normTitle:  "nippon sangoku die drei nationen der roten sonne",
+			candidates: []string{"Nippon"},
+			want:       false,
+		},
+		{
+			name:       "single_word_exact_match",
+			normTitle:  "halo",
+			candidates: []string{"Halo"},
+			want:       true,
+		},
+		{
 			name:       "empty_candidate",
 			normTitle:  "some show",
 			candidates: []string{""},

--- a/internal/metadata/titles_test.go
+++ b/internal/metadata/titles_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package metadata
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ShortenedTitles(t *testing.T) {
+	tests := []struct {
+		name      string
+		normTitle string
+		want      []string
+	}{
+		{
+			name:      "localized_subtitle",
+			normTitle: "nippon sangoku die drei nationen der roten sonne",
+			want: []string{
+				"nippon sangoku die drei nationen der",
+				"nippon sangoku die drei nationen",
+				"nippon sangoku die drei",
+				"nippon sangoku die",
+				"nippon sangoku",
+			},
+		},
+		{
+			name:      "very_long_title_capped_at_six_words",
+			normTitle: "ive been killing slimes for 300 years and maxed out my level",
+			want: []string{
+				"ive been killing slimes for 300",
+				"ive been killing slimes for",
+				"ive been killing slimes",
+				"ive been killing",
+				"ive been",
+			},
+		},
+		{
+			name:      "three_words",
+			normTitle: "orphan black echoes",
+			want:      []string{"orphan black"},
+		},
+		{
+			name:      "two_words",
+			normTitle: "demon slayer",
+			want:      nil,
+		},
+		{
+			name:      "single_word",
+			normTitle: "halo",
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, shortenedTitles(tt.normTitle), "shortenedTitles(%q)", tt.normTitle)
+		})
+	}
+}
+
+func Test_MatchesTitle(t *testing.T) {
+	tests := []struct {
+		name       string
+		normTitle  string
+		candidates []string
+		want       bool
+	}{
+		{
+			name:       "exact_translation_match",
+			normTitle:  "nippon sangoku die drei nationen der roten sonne",
+			candidates: []string{"日本三國", "NIPPON SANGOKU: Die drei Nationen der roten Sonne"},
+			want:       true,
+		},
+		{
+			name:       "name_is_leading_part_of_title",
+			normTitle:  "nippon sangoku die drei nationen der roten sonne",
+			candidates: []string{"Nippon Sangoku"},
+			want:       true,
+		},
+		{
+			name:       "unrelated_show",
+			normTitle:  "nippon sangoku die drei nationen der roten sonne",
+			candidates: []string{"Nippon Television Special"},
+			want:       false,
+		},
+		{
+			name:       "partial_word_does_not_match",
+			normTitle:  "sangokushi the story of three kingdoms",
+			candidates: []string{"Sangoku"},
+			want:       false,
+		},
+		{
+			name:       "empty_candidate",
+			normTitle:  "some show",
+			candidates: []string{""},
+			want:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, matchesTitle(tt.normTitle, tt.candidates...), "matchesTitle(%q, %v)", tt.normTitle, tt.candidates)
+		})
+	}
+}

--- a/internal/metadata/tvdb.go
+++ b/internal/metadata/tvdb.go
@@ -36,10 +36,12 @@ type loginResponse struct {
 type searchResponse struct {
 	Status string `json:"status"`
 	Data   []struct {
-		Name      string `json:"name"`
-		TvdbID    string `json:"tvdb_id"`
-		Year      string `json:"year"`
-		RemoteIds []struct {
+		Name         string            `json:"name"`
+		TvdbID       string            `json:"tvdb_id"`
+		Year         string            `json:"year"`
+		Aliases      []string          `json:"aliases,omitempty"`
+		Translations map[string]string `json:"translations,omitempty"`
+		RemoteIds    []struct {
 			ID         string `json:"id"`
 			Type       int    `json:"type"`
 			SourceName string `json:"sourceName"`
@@ -167,26 +169,59 @@ func (t *tvdbClient) makeAPIRequest(endpoint string) ([]byte, error) {
 	return body, nil
 }
 
-func (t *tvdbClient) search(title string, year int) (string, error) {
-	resp, err := t.makeAPIRequest(fmt.Sprintf("/search?query=%s&type=series&year=%d", url.QueryEscape(rls.MustNormalize(title)), year))
+func (t *tvdbClient) searchSeries(query string, year int) (searchResponse, error) {
+	resp, err := t.makeAPIRequest(fmt.Sprintf("/search?query=%s&type=series&year=%d", url.QueryEscape(query), year))
 	if err != nil {
-		return "", err
+		return searchResponse{}, err
 	}
 
 	var searchResp searchResponse
 	if err := json.NewDecoder(bytes.NewReader(resp)).Decode(&searchResp); err != nil {
-		return "", err
+		return searchResponse{}, err
 	}
 
 	if searchResp.Status != "success" {
-		return "", fmt.Errorf("failed to get data from tvdb")
+		return searchResponse{}, fmt.Errorf("failed to get data from tvdb")
 	}
 
-	if len(searchResp.Data) == 0 {
-		return "", fmt.Errorf("failed to find show %q on tvdb", title)
+	return searchResp, nil
+}
+
+func (t *tvdbClient) search(title string, year int) (string, error) {
+	normTitle := rls.MustNormalize(title)
+
+	searchResp, err := t.searchSeries(normTitle, year)
+	if err != nil {
+		return "", err
 	}
 
-	return searchResp.Data[0].TvdbID, nil
+	if len(searchResp.Data) > 0 {
+		return searchResp.Data[0].TvdbID, nil
+	}
+
+	// the tvdb search endpoint regularly returns no results for long titles,
+	// even when they exactly match a registered translation of a show; retry
+	// with shortened title variants and only accept a show whose name, alias
+	// or translation matches the original title
+	for _, shortTitle := range shortenedTitles(normTitle) {
+		searchResp, err = t.searchSeries(shortTitle, year)
+		if err != nil {
+			return "", err
+		}
+
+		for _, result := range searchResp.Data {
+			candidates := append([]string{result.Name}, result.Aliases...)
+			for _, translation := range result.Translations {
+				candidates = append(candidates, translation)
+			}
+
+			if matchesTitle(normTitle, candidates...) {
+				return result.TvdbID, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to find show %q on tvdb", title)
 }
 
 // episodesInSeason returns the number of episodes in a season of a show.

--- a/internal/metadata/tvdb.go
+++ b/internal/metadata/tvdb.go
@@ -221,7 +221,7 @@ func (t *tvdbClient) search(title string, year int) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("failed to find show %q on tvdb", title)
+	return "", fmt.Errorf("no matching search results")
 }
 
 // episodesInSeason returns the number of episodes in a season of a show.

--- a/internal/metadata/tvdb_test.go
+++ b/internal/metadata/tvdb_test.go
@@ -4,13 +4,19 @@
 package metadata
 
 import (
+	"os"
 	"testing"
 
 	"github.com/moistari/rls"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_TVMaze_EpisodesInSeason(t *testing.T) {
+func Test_TVDB_EpisodesInSeason(t *testing.T) {
+	apiKey := os.Getenv("TVDB_API_KEY")
+	if apiKey == "" {
+		t.Skip("TVDB_API_KEY not set, skipping TVDB tests")
+	}
+
 	tests := []struct {
 		name    string
 		release rls.Release
@@ -27,22 +33,22 @@ func Test_TVMaze_EpisodesInSeason(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "anime_show",
+			name: "show_with_localized_subtitle",
 			release: rls.Release{
-				Title:  "Demon Slayer",
+				Title:  "NIPPON SANGOKU Die drei Nationen der roten Sonne",
 				Series: 1,
 			},
-			want:    26,
+			want:    12,
 			wantErr: false,
 		},
 		{
-			name: "season_doesnt_exist",
+			name: "long_title_not_found_by_tvdb_search",
 			release: rls.Release{
-				Title:  "Game of Thrones",
-				Series: 15,
+				Title:  "My Next Life as a Villainess All Routes Lead to Doom",
+				Series: 1,
 			},
-			want:    0,
-			wantErr: true,
+			want:    12,
+			wantErr: false,
 		},
 		{
 			name: "show_doesnt_exist",
@@ -53,42 +59,15 @@ func Test_TVMaze_EpisodesInSeason(t *testing.T) {
 			want:    0,
 			wantErr: true,
 		},
-		{
-			name: "some_recent_show",
-			release: rls.Release{
-				Title:  "Echo",
-				Series: 1,
-			},
-			want:    5,
-			wantErr: false,
-		},
-		{
-			name: "show_with_punctuation",
-			release: rls.Release{
-				Title:  "Orphan Black - Echoes",
-				Series: 1,
-			},
-			want:    10,
-			wantErr: false,
-		},
-		{
-			name: "show_with_localized_subtitle",
-			release: rls.Release{
-				Title:  "NIPPON SANGOKU Die drei Nationen der roten Sonne",
-				Series: 1,
-			},
-			want:    12,
-			wantErr: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tvmazeClient := newTVMaze()
+			tvdbClient := newTVDB(apiKey, os.Getenv("TVDB_PIN"))
 
-			got, err := tvmazeClient.episodesInSeason(tt.release)
+			got, err := tvdbClient.episodesInSeason(tt.release)
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("episodesInSeason() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			assert.Equalf(t, tt.want, got, "TVDB EpisodesInSeason(%s, %d)", tt.release.Title, tt.release.Series)

--- a/internal/metadata/tvmaze.go
+++ b/internal/metadata/tvmaze.go
@@ -20,20 +20,54 @@ func newTVMaze() provider {
 	return &tvmazeClient{}
 }
 
-// episodesInSeason returns the number of episodes in a season of a show.
-func (t *tvmazeClient) episodesInSeason(release rls.Release) (int, error) {
+// findShow tries to find a show on tvmaze, first with the given title, then
+// with its normalized form, and finally with shortened title variants.
+func (t *tvmazeClient) findShow(title string) (*tvmaze.Show, error) {
 	// try finding the show with the parsed title first
-	show, showErr := tvmaze.DefaultClient.GetShow(release.Title)
-	if showErr != nil {
-		if showErr.Error() != errNotFound {
-			return 0, fmt.Errorf("failed to find show %q on tvmaze: %w", release.Title, showErr)
+	show, showErr := tvmaze.DefaultClient.GetShow(title)
+	if showErr == nil {
+		return show, nil
+	}
+	if showErr.Error() != errNotFound {
+		return nil, showErr
+	}
+
+	// retry with the normalized title if the parsed title fails
+	normTitle := rls.MustNormalize(title)
+	show, showErr = tvmaze.DefaultClient.GetShow(normTitle)
+	if showErr == nil {
+		return show, nil
+	}
+	if showErr.Error() != errNotFound {
+		return nil, showErr
+	}
+
+	// tvmaze often doesn't list localized titles, e.g. when a release name
+	// carries a localized subtitle after the actual show title; retry with
+	// shortened title variants and only accept a show whose name matches the
+	// leading words of the original title
+	for _, shortTitle := range shortenedTitles(normTitle) {
+		show, err := tvmaze.DefaultClient.GetShow(shortTitle)
+		if err != nil {
+			if err.Error() == errNotFound {
+				continue
+			}
+			return nil, err
 		}
 
-		// retry with the normalized title if the parsed title fails
-		show, showErr = tvmaze.DefaultClient.GetShow(rls.MustNormalize(release.Title))
-		if showErr != nil {
-			return 0, fmt.Errorf("failed to find show %q on tvmaze: %w", release.Title, showErr)
+		if matchesTitle(normTitle, show.Name) {
+			return show, nil
 		}
+	}
+
+	return nil, showErr
+}
+
+// episodesInSeason returns the number of episodes in a season of a show.
+func (t *tvmazeClient) episodesInSeason(release rls.Release) (int, error) {
+	show, showErr := t.findShow(release.Title)
+	if showErr != nil {
+		return 0, fmt.Errorf("failed to find show %q on tvmaze: %w", release.Title, showErr)
 	}
 
 	episodes, err := show.GetEpisodes()

--- a/internal/metadata/tvmaze.go
+++ b/internal/metadata/tvmaze.go
@@ -32,14 +32,17 @@ func (t *tvmazeClient) findShow(title string) (*tvmaze.Show, error) {
 		return nil, showErr
 	}
 
-	// retry with the normalized title if the parsed title fails
+	// retry with the normalized title if the parsed title fails and
+	// normalizing actually changes it
 	normTitle := rls.MustNormalize(title)
-	show, showErr = tvmaze.DefaultClient.GetShow(normTitle)
-	if showErr == nil {
-		return show, nil
-	}
-	if showErr.Error() != errNotFound {
-		return nil, showErr
+	if normTitle != title {
+		show, showErr = tvmaze.DefaultClient.GetShow(normTitle)
+		if showErr == nil {
+			return show, nil
+		}
+		if showErr.Error() != errNotFound {
+			return nil, showErr
+		}
 	}
 
 	// tvmaze often doesn't list localized titles, e.g. when a release name


### PR DESCRIPTION
## Problem

Season pack lookups fail with `could not get episode count` for releases whose parsed title is long or carries a localized subtitle, e.g. `NIPPON.SANGOKU.Die.drei.Nationen.der.roten.Sonne.S01.German.DL...`:

- **TVDB**: the `/search` endpoint regularly returns zero results for queries of 7+ words — even when the query exactly matches a translation registered on the series. Verified against the live API with several shows ("I Know What You Did Last Summer", "My Next Life as a Villainess: All Routes Lead to Doom", "I've Been Killing Slimes for 300 Years and Maxed Out My Level", "The Guy She Was Interested in Wasn't a Guy at All" all return 0 results for their full titles). Every one of them matches once trailing words are dropped; no failure was observed for queries of 6 words or fewer.
- **TVMaze**: localized titles are often not listed as AKAs (Nippon Sangoku has EN/RU/HU/UA AKAs but no German one), so `singlesearch` 404s.

## Fix

When the full-title search comes up empty, both providers retry with progressively shortened title variants (dropping one trailing word at a time). To avoid matching an unrelated show, a shortened-query result is only accepted if one of its names matches the original title exactly or as its leading words — for TVDB that's checked against `name`, `aliases` and `translations` of each search result, for TVMaze against the show name.

The variant chain starts at 6 words (where TVDB search becomes reliable) and stops at 2, bounding the fallback at **5 extra calls per provider** so worst-case bursts stay well below the TVMaze rate limit of 20 calls per 10 seconds. The happy path is unchanged: one call per provider, and the fallback only runs where lookups previously hard-failed.

## Tests

- Unit tests for the new `shortenedTitles`/`matchesTitle` helpers
- The failing release added as a live TVMaze regression case (12 episodes)
- New `tvdb_test.go` suite, gated behind the `TVDB_API_KEY` env var and skipped otherwise — passes live, including an 11-word title that TVDB search can't find directly
- `go test ./...` green, `gofumpt` applied

Also ignores `.env` files and documents the lookup strategy in ARCHITECTURE.md.