### PR TITLE
feat(metadata): cache episode counts with a TTL

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,7 @@
 - Providers: TVDB and TVMaze
 - Purpose: estimate total episodes for smart-mode decisions and cross-check provider disagreement
 - Lookup strategy: search with the parsed release title first, then retry with progressively shortened title variants (guarded by name/alias/translation matching), because provider searches often miss long or localized titles
+- Caching: successful episode counts are cached for 6 hours keyed by normalized title, year and season; concurrent lookups for the same key are collapsed via singleflight, so cross-seed announce bursts trigger only one provider fetch
 
 ### File Operations
 
@@ -90,6 +91,7 @@ Current explicit test coverage exists in:
 
 - `internal/release/release_test.go`
 - `internal/format/format_test.go`
+- `internal/metadata/metadata_test.go`
 - `internal/metadata/titles_test.go`
 - `internal/metadata/tvdb_test.go` (requires `TVDB_API_KEY` env var, skipped otherwise)
 - `internal/metadata/tvmaze_test.go`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,7 +49,7 @@
 - Providers: TVDB and TVMaze
 - Purpose: estimate total episodes for smart-mode decisions and cross-check provider disagreement
 - Lookup strategy: search with the parsed release title first, then retry with progressively shortened title variants (guarded by name/alias/translation matching), because provider searches often miss long or localized titles
-- Caching: successful episode counts are cached for 6 hours keyed by normalized title, year and season; concurrent lookups for the same key are collapsed via singleflight, so cross-seed announce bursts trigger only one provider fetch
+- Caching: successful episode counts are cached for 6 hours keyed by normalized title, year and season; concurrent lookups for the same key are collapsed via singleflight, so cross-seed announce bursts trigger only one provider fetch; expired entries are swept on each store, bounding the cache to the keys seen in the last TTL window
 
 ### File Operations
 

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -80,8 +80,17 @@ func (m *Provider) EpisodesInSeason(release rls.Release) (int, error) {
 			return 0, err
 		}
 
+		// sweep expired entries while holding the lock for the store, so the
+		// cache never grows beyond the keys seen in the last TTL window; the
+		// read path stays iteration-free
 		m.cacheMu.Lock()
-		m.cache[key] = cacheEntry{episodes: episodes, expiresAt: time.Now().Add(episodeCacheTTL)}
+		now := time.Now()
+		for k, e := range m.cache {
+			if now.After(e.expiresAt) {
+				delete(m.cache, k)
+			}
+		}
+		m.cache[key] = cacheEntry{episodes: episodes, expiresAt: now.Add(episodeCacheTTL)}
 		m.cacheMu.Unlock()
 
 		return episodes, nil

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -6,22 +6,39 @@ package metadata
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/internal/logger"
 
 	"github.com/moistari/rls"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/singleflight"
 )
+
+// episodeCacheTTL bounds how long a fetched episode count is reused. It covers
+// both announce bursts of the same season pack, which arrive within seconds of
+// each other, and cross-seed propagation, where the same pack shows up on other
+// trackers over the following hours. Provider episode counts are near-static,
+// so staleness is a minor concern next to the saved calls.
+const episodeCacheTTL = 6 * time.Hour
 
 type provider interface {
 	episodesInSeason(release rls.Release) (int, error)
+}
+
+type cacheEntry struct {
+	episodes  int
+	expiresAt time.Time
 }
 
 type Provider struct {
 	log          zerolog.Logger
 	tvmazeClient provider
 	tvdbClient   provider
+	cache        map[string]cacheEntry
+	cacheMu      sync.Mutex
+	group        singleflight.Group
 }
 
 func NewMetadataProvider(log logger.Logger, metadata domain.Metadata) *Provider {
@@ -36,10 +53,47 @@ func NewMetadataProvider(log logger.Logger, metadata domain.Metadata) *Provider 
 		log:          log.With().Logger(),
 		tvmazeClient: tvmaze,
 		tvdbClient:   tvdb,
+		cache:        make(map[string]cacheEntry),
 	}
 }
 
+// EpisodesInSeason returns the number of episodes in a season of a show,
+// caching successful lookups so repeated announces of the same season pack,
+// e.g. from cross-seeded trackers, don't trigger duplicate provider calls.
+// Concurrent lookups for the same key are collapsed into a single fetch.
 func (m *Provider) EpisodesInSeason(release rls.Release) (int, error) {
+	key := fmt.Sprintf("%s|%d|%d", rls.MustNormalize(release.Title), release.Year, release.Series)
+
+	m.cacheMu.Lock()
+	entry, ok := m.cache[key]
+	m.cacheMu.Unlock()
+
+	if ok && time.Now().Before(entry.expiresAt) {
+		m.log.Debug().Msgf("using cached episode count for %s S%02d: %d",
+			release.Title, release.Series, entry.episodes)
+		return entry.episodes, nil
+	}
+
+	episodes, err, _ := m.group.Do(key, func() (any, error) {
+		episodes, err := m.fetchEpisodesInSeason(release)
+		if err != nil {
+			return 0, err
+		}
+
+		m.cacheMu.Lock()
+		m.cache[key] = cacheEntry{episodes: episodes, expiresAt: time.Now().Add(episodeCacheTTL)}
+		m.cacheMu.Unlock()
+
+		return episodes, nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return episodes.(int), nil
+}
+
+func (m *Provider) fetchEpisodesInSeason(release rls.Release) (int, error) {
 	if m.tvdbClient == nil {
 		return m.tvmazeClient.episodesInSeason(release)
 	}

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package metadata
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/moistari/rls"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeProvider struct {
+	calls    atomic.Int32
+	episodes int
+	err      error
+	delay    time.Duration
+}
+
+func (f *fakeProvider) episodesInSeason(release rls.Release) (int, error) {
+	f.calls.Add(1)
+	time.Sleep(f.delay)
+	return f.episodes, f.err
+}
+
+func newTestProvider(fake *fakeProvider) *Provider {
+	return &Provider{
+		log:          zerolog.Nop(),
+		tvmazeClient: fake,
+		cache:        make(map[string]cacheEntry),
+	}
+}
+
+func Test_EpisodesInSeason_CachesWithinTTL(t *testing.T) {
+	fake := &fakeProvider{episodes: 10}
+	p := newTestProvider(fake)
+	release := rls.Release{Title: "Some Show", Series: 1}
+
+	for range 3 {
+		got, err := p.EpisodesInSeason(release)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, got)
+	}
+
+	assert.Equal(t, int32(1), fake.calls.Load())
+}
+
+func Test_EpisodesInSeason_RefetchesAfterExpiry(t *testing.T) {
+	fake := &fakeProvider{episodes: 10}
+	p := newTestProvider(fake)
+	release := rls.Release{Title: "Some Show", Series: 1}
+
+	_, err := p.EpisodesInSeason(release)
+	assert.NoError(t, err)
+
+	// expire the cached entry
+	p.cacheMu.Lock()
+	for key, entry := range p.cache {
+		entry.expiresAt = time.Now().Add(-time.Minute)
+		p.cache[key] = entry
+	}
+	p.cacheMu.Unlock()
+
+	_, err = p.EpisodesInSeason(release)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), fake.calls.Load())
+}
+
+func Test_EpisodesInSeason_CollapsesConcurrentLookups(t *testing.T) {
+	fake := &fakeProvider{episodes: 10, delay: 50 * time.Millisecond}
+	p := newTestProvider(fake)
+	release := rls.Release{Title: "Some Show", Series: 1}
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			got, err := p.EpisodesInSeason(release)
+			assert.NoError(t, err)
+			assert.Equal(t, 10, got)
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), fake.calls.Load())
+}
+
+func Test_EpisodesInSeason_DoesNotCacheErrors(t *testing.T) {
+	fake := &fakeProvider{err: fmt.Errorf("provider down")}
+	p := newTestProvider(fake)
+	release := rls.Release{Title: "Some Show", Series: 1}
+
+	for range 2 {
+		_, err := p.EpisodesInSeason(release)
+		assert.Error(t, err)
+	}
+
+	assert.Equal(t, int32(2), fake.calls.Load())
+}
+
+func Test_EpisodesInSeason_SeparateCacheKeys(t *testing.T) {
+	fake := &fakeProvider{episodes: 10}
+	p := newTestProvider(fake)
+
+	_, err := p.EpisodesInSeason(rls.Release{Title: "Some Show", Series: 1})
+	assert.NoError(t, err)
+	_, err = p.EpisodesInSeason(rls.Release{Title: "Some Show", Series: 2})
+	assert.NoError(t, err)
+	_, err = p.EpisodesInSeason(rls.Release{Title: "Other Show", Series: 1})
+	assert.NoError(t, err)
+
+	assert.Equal(t, int32(3), fake.calls.Load())
+}

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -102,6 +102,32 @@ func Test_EpisodesInSeason_DoesNotCacheErrors(t *testing.T) {
 	assert.Equal(t, int32(2), fake.calls.Load())
 }
 
+func Test_EpisodesInSeason_EvictsExpiredEntriesOnStore(t *testing.T) {
+	fake := &fakeProvider{episodes: 10}
+	p := newTestProvider(fake)
+
+	_, err := p.EpisodesInSeason(rls.Release{Title: "Old Show", Series: 1})
+	assert.NoError(t, err)
+	_, err = p.EpisodesInSeason(rls.Release{Title: "Stale Show", Series: 1})
+	assert.NoError(t, err)
+
+	// expire "Old Show" and "Stale Show"
+	p.cacheMu.Lock()
+	for key, entry := range p.cache {
+		entry.expiresAt = time.Now().Add(-time.Minute)
+		p.cache[key] = entry
+	}
+	p.cacheMu.Unlock()
+
+	// storing a fresh entry sweeps the expired ones
+	_, err = p.EpisodesInSeason(rls.Release{Title: "New Show", Series: 1})
+	assert.NoError(t, err)
+
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+	assert.Len(t, p.cache, 1)
+}
+
 func Test_EpisodesInSeason_SeparateCacheKeys(t *testing.T) {
 	fake := &fakeProvider{episodes: 10}
 	p := newTestProvider(fake)


### PR DESCRIPTION
## What changed

Season pack announces for the same release (cross-seed bursts within seconds, propagation across trackers over hours) each triggered a full metadata lookup, which since #230 can cost up to ~13 provider calls on the fallback path. Successful episode counts are now cached in memory for 6 hours, and concurrent lookups for the same show collapse into a single fetch via singleflight, so a burst of announces results in exactly one TVDB+TVMaze round-trip. Errors are never cached, keeping transient provider failures retryable.

Expiry is lazy with an eviction sweep on every store: reads stay iteration-free, and writing a fresh entry deletes all expired ones under the same lock. The cache is bounded to the keys seen within the last TTL window, no janitor goroutine needed.

## Files changed

- `internal/metadata/metadata.go`: TTL cache keyed by normalized title, year and season wrapped around the provider fan-out in `EpisodesInSeason` (now `fetchEpisodesInSeason`); concurrent same-key lookups deduplicated with `golang.org/x/sync/singleflight`; expired entries swept on store
- `internal/metadata/metadata_test.go`: cache behavior tests with a counting fake provider: hit within TTL, refetch after expiry, concurrent collapse, errors not cached, distinct keys per title/season, expired entries evicted on store
- `go.mod`/`go.sum`: promote `golang.org/x/sync` to a direct dependency (v0.22.0)
- `ARCHITECTURE.md`: document the caching strategy