### PR TITLE
chore(license): add missing headers and bump year to 2026

### DIFF
--- a/cmd/genToken.go
+++ b/cmd/genToken.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package cmd

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package cmd

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package cmd

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package cmd

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package cmd

--- a/internal/api/token.go
+++ b/internal/api/token.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package api

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package buildinfo

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is heavily modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package config
 
 import (

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/domain/http.go
+++ b/internal/domain/http.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/domain/notification.go
+++ b/internal/domain/notification.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is heavily modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/domain/release.go
+++ b/internal/domain/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package domain

--- a/internal/files/hardlink.go
+++ b/internal/files/hardlink.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package files

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package format

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package format

--- a/internal/http/health.go
+++ b/internal/http/health.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is slightly modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/processor_test.go
+++ b/internal/http/processor_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is slightly modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/http/webhook.go
+++ b/internal/http/webhook.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package http

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is slightly modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/metadata/titles.go
+++ b/internal/metadata/titles.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/metadata/titles_test.go
+++ b/internal/metadata/titles_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/metadata/tvdb.go
+++ b/internal/metadata/tvdb.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/metadata/tvdb_test.go
+++ b/internal/metadata/tvdb_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/metadata/tvmaze.go
+++ b/internal/metadata/tvmaze.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/metadata/tvmaze_test.go
+++ b/internal/metadata/tvmaze_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package metadata

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is heavily modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/notification/message_builder.go
+++ b/internal/notification/message_builder.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // Code is heavily modified for use with seasonpackarr
 // SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/internal/payload/payload.go
+++ b/internal/payload/payload.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package payload

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package release

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package release
 
 import (

--- a/internal/slices/slices.go
+++ b/internal/slices/slices.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package slices

--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package slices

--- a/internal/torrentclient/client.go
+++ b/internal/torrentclient/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrentclient

--- a/internal/torrentclient/client_test.go
+++ b/internal/torrentclient/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrentclient

--- a/internal/torrentclient/qbittorrent.go
+++ b/internal/torrentclient/qbittorrent.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrentclient

--- a/internal/torrentclient/transmission.go
+++ b/internal/torrentclient/transmission.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrentclient

--- a/internal/torrentclient/transmission_live_test.go
+++ b/internal/torrentclient/transmission_live_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrentclient

--- a/internal/torrentclient/transmission_test.go
+++ b/internal/torrentclient/transmission_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrentclient

--- a/internal/torrents/decode.go
+++ b/internal/torrents/decode.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, KyleSanderson, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, KyleSanderson, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrents

--- a/internal/torrents/mock.go
+++ b/internal/torrents/mock.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
 package torrents
 
 import (

--- a/internal/torrents/torrents.go
+++ b/internal/torrents/torrents.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrents

--- a/internal/torrents/torrents_test.go
+++ b/internal/torrents/torrents_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package torrents

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025, nuxen and the seasonpackarr contributors.
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package main

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 - 2025, Ludvig Lundgren and the autobrr contributors.
+// Copyright (c) 2021 - 2026, Ludvig Lundgren and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 package errors


### PR DESCRIPTION
## Why

Three Go files never got a license header: `internal/config/config_test.go`, `internal/release/release_test.go` and `internal/torrents/mock.go`. Every other file still claimed 2025.

## What changed

Added the standard nuxen header to the three files that were missing one. They are all original to this repo, so none of them take the autobrr attribution.

Bumped the end year from 2025 to 2026 across all 49 files that already had a header. That covers the autobrr attributed files (`2021 - 2025, Ludvig Lundgren`) and `torrents/decode.go` (`KyleSanderson, nuxen`), matching how #56 and #174 handled the previous bumps: one uniform range for the whole repo rather than a per file modification year.

Header lines only. The diff is exactly one changed line per existing file plus three new headers, no code touched.

## Tests

No behavior change, so no new tests. The existing suite passes.