### PR TITLE
fix: publish validated config snapshots

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,9 @@
 ### Configuration
 
 - Implemented in `internal/config/` and `internal/domain/config.go`
-- Concerns: defaults, config file discovery, dynamic reload, validation, config rendering
+- Concerns: defaults, config file discovery, validated immutable snapshots, dynamic reload, config rendering
+- Runtime readers acquire one snapshot per request or operation. Reload publishes a candidate only after file parsing,
+  environment overrides, and validation succeed.
 - Durable contract surfaces: `config.yaml`, `schemas/config-schema.json`, README config docs
 
 ### HTTP/API

--- a/README.md
+++ b/README.md
@@ -124,6 +124,30 @@ will need to adjust the created config file to your needs and start the containe
 You can configure a decent part of the features seasonpackarr provides. I will explain the most important ones here in
 more detail.
 
+### Config Reload
+
+seasonpackarr watches the active `config.yaml` file. It loads each change into a new snapshot, reapplies
+`SEASONPACKARR__...` environment overrides, and validates the complete result before it becomes active. An invalid or
+partially written file is rejected. The last valid config stays active.
+
+These settings reload while seasonpackarr runs:
+
+- torrent client connections and import policies
+- API token
+- smart mode and fuzzy matching
+- Discord webhook and notification levels
+- log level
+
+These settings configure components that start once and require a restart:
+
+- server host and port
+- metadata provider credentials
+- log path, maximum size, and backup count
+- `disableConfigFile`
+
+The restart after the first generated config edit is still required because the initial process exits when its client
+configuration is incomplete.
+
 ### Torrent Client Configuration
 
 Each entry under `clients` connects seasonpackarr to one torrent client instance. Set the `type` field to either

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,18 +27,21 @@ var startCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// read config
 		cfg := config.New(configPath, buildinfo.Version)
+		snapshot := cfg.Snapshot()
 
 		// init new logger
-		log := logger.New(cfg.Config)
+		log := logger.New(&snapshot)
 
 		// init dynamic config
-		cfg.DynamicReload(log)
+		if _, err := cfg.DynamicReload(log); err != nil {
+			log.Fatal().Err(err).Msg("failed to start config reload watcher")
+		}
 
 		// init notification sender
 		noti := notification.NewDiscordSender(log, cfg)
 
 		// init metadata providers
-		metadata := metadata.NewMetadataProvider(log, cfg.Config.Metadata)
+		metadata := metadata.NewMetadataProvider(log, snapshot.Metadata)
 
 		srv := http.NewServer(log, cfg, noti, metadata)
 
@@ -46,7 +49,7 @@ var startCmd = &cobra.Command{
 		log.Info().Msgf("Version: %s", buildinfo.Version)
 		log.Info().Msgf("Commit: %s", buildinfo.Commit)
 		log.Info().Msgf("Build date: %s", buildinfo.Date)
-		log.Info().Msgf("Log-level: %s", cfg.Config.LogLevel)
+		log.Info().Msgf("Log-level: %s", snapshot.LogLevel)
 
 		errorChannel := make(chan error)
 		go func() {

--- a/docs/RELIABILITY.md
+++ b/docs/RELIABILITY.md
@@ -16,6 +16,8 @@ Reliable does not mean perfect acceptance. It means predictable outcomes when de
 - API token middleware
 - health endpoints
 - structured logging
+- validated, immutable config snapshots that keep the last valid config after a rejected reload
+- environment precedence reapplied on every config reload
 - TVDB/TVMaze fallback strategy
 - release comparison gates
 - hardlink creation isolated from matching logic

--- a/docs/product-specs/config-reload.md
+++ b/docs/product-specs/config-reload.md
@@ -42,6 +42,7 @@ These changes require a process restart.
 ## Acceptance Bar
 
 - invalid YAML or invalid client settings keep the last valid config active
+- truncate-first file writes never publish an empty intermediate snapshot
 - environment values keep precedence after every reload
 - omitted optional keys return to built-in defaults
 - concurrent readers do not race with reload publication

--- a/docs/product-specs/config-reload.md
+++ b/docs/product-specs/config-reload.md
@@ -1,0 +1,48 @@
+# Config Reload
+
+## Operator Promise
+
+seasonpackarr watches the active `config.yaml` file while the service runs. A reload must not expose a partial or
+invalid config to requests.
+
+For each file change, seasonpackarr:
+
+1. starts from built-in defaults
+2. loads the complete YAML file
+3. reapplies `SEASONPACKARR__...` environment overrides
+4. validates deprecated settings and every torrent client
+5. atomically publishes the new immutable snapshot
+
+If any step fails, seasonpackarr logs the rejection and keeps the last valid snapshot.
+
+## Live Settings
+
+The following settings apply without a restart:
+
+- torrent client connections and import policies
+- API token
+- smart mode and fuzzy matching
+- Discord webhook and notification levels
+- log level
+
+Each request or notification uses one coherent snapshot. A client configuration change also replaces the cached
+client adapter and its torrent-entry cache on the next use.
+
+## Restart-Only Settings
+
+The following settings configure components that start once:
+
+- server host and port
+- metadata provider credentials
+- log path, maximum size, and backup count
+- `disableConfigFile`
+
+These changes require a process restart.
+
+## Acceptance Bar
+
+- invalid YAML or invalid client settings keep the last valid config active
+- environment values keep precedence after every reload
+- omitted optional keys return to built-in defaults
+- concurrent readers do not race with reload publication
+- automatic config discovery watches the file that was actually loaded

--- a/docs/product-specs/index.md
+++ b/docs/product-specs/index.md
@@ -6,6 +6,7 @@ Product specs define user-visible behavior and operator expectations.
 
 | Doc | Audience | Scope | Status |
 | --- | --- | --- | --- |
+| `config-reload.md` | Operators and maintainers | Live reload guarantees and restart-only settings | Active |
 | `new-user-onboarding.md` | New operators | First setup and first successful run | Active |
 | `webhook-contract.md` | Integrators and maintainers | Authenticated API behavior and integration expectations | Active |
 

--- a/docs/references/configuration-surface-llms.txt
+++ b/docs/references/configuration-surface-llms.txt
@@ -11,6 +11,9 @@ seasonpackarr configuration surface reference
 - qBittorrent clients must set import.savePath or import.category; without savePath, the destination follows qBittorrent automatic-management and manual category-path preferences
 - Transmission has no categories or content layout; empty import.savePath falls back to the session download dir; Transmission always hash-checks existing data on add, so imports verify before starting
 - parseTorrentFile and clients.<name>.preImportPath are removed; startup hard-fails with a migration message if they (or their env vars) are still present
+- config reload builds a new immutable snapshot, reapplies SEASONPACKARR__ environment overrides, validates it, and publishes it atomically; invalid reloads keep the last valid snapshot
+- live reload applies client connections/import policies, apiToken, smart/fuzzy matching, notifications, and logLevel
+- host/port, metadata credentials, log file output settings, and disableConfigFile require restart
 - high-signal settings:
   - host
   - port

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"text/template"
+	"time"
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/internal/logger"
@@ -756,6 +757,16 @@ func (c *AppConfig) Snapshot() domain.Config {
 }
 
 func (c *AppConfig) reload() (*domain.Config, error) {
+	if !c.disableConfigFile {
+		contents, err := os.ReadFile(c.configFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading config file %s: %w", c.configFile, err)
+		}
+		if len(bytes.TrimSpace(contents)) == 0 {
+			return nil, fmt.Errorf("config file %s is empty", c.configFile)
+		}
+	}
+
 	snapshot, err := c.loadSnapshot()
 	if err != nil {
 		return nil, err
@@ -763,6 +774,8 @@ func (c *AppConfig) reload() (*domain.Config, error) {
 	c.current.Store(snapshot)
 	return snapshot, nil
 }
+
+const configReloadSettleDelay = 10 * time.Millisecond
 
 func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 	if c.disableConfigFile {
@@ -779,6 +792,11 @@ func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 			log.Error().Err(watchErr).Msg("error watching config file")
 			return
 		}
+
+		// On Linux, a direct write can emit a truncate event before the new
+		// contents are available. Let the write settle before loading it. Slower
+		// writes remain protected by reload's empty-file check.
+		time.Sleep(configReloadSettleDelay)
 
 		snapshot, err := c.reload()
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,11 +10,11 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"text/template"
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
@@ -374,14 +374,16 @@ func (c *AppConfig) writeConfig(configPath string, configFile string) error {
 	return nil
 }
 
-type Config interface {
-	DynamicReload(log logger.Logger)
+type Provider interface {
+	Snapshot() domain.Config
 }
 
 type AppConfig struct {
-	Config *domain.Config
-	m      *sync.Mutex
-	k      *koanf.Koanf
+	current           atomic.Pointer[domain.Config]
+	configFile        string
+	version           string
+	disableConfigFile bool
+	watcher           *file.File
 }
 
 func New(configPath string, version string) *AppConfig {
@@ -392,34 +394,24 @@ func New(configPath string, version string) *AppConfig {
 			"The only difference between the old and the new config is, that the qbit client info is now stored in an array to allow for multiple clients to be configured.")
 	}
 
-	// init app config
 	c := &AppConfig{
-		Config: &domain.Config{
-			Version:    version,
-			ConfigPath: configPath,
-		},
-		m: new(sync.Mutex),
-		k: koanf.New("."),
+		version:           version,
+		disableConfigFile: os.Getenv("SEASONPACKARR__DISABLE_CONFIG_FILE") == "true",
 	}
 
-	c.defaults()
-	c.Config.DisableConfigFile = os.Getenv("SEASONPACKARR__DISABLE_CONFIG_FILE") == "true"
-
-	if !c.Config.DisableConfigFile {
-		c.load()
-	}
-
-	if err := validateDeprecatedConfigInputs(c.k, os.LookupEnv); err != nil {
-		log.Fatal(err)
-	}
-
-	c.loadFromEnv()
-
-	for clientName, client := range c.Config.Clients {
-		if err := validateClientConfig(clientName, client); err != nil {
+	if !c.disableConfigFile {
+		configFile, err := c.resolveConfigFile(configPath)
+		if err != nil {
 			log.Fatal(err)
 		}
+		c.configFile = configFile
 	}
+
+	snapshot, err := c.loadSnapshot()
+	if err != nil {
+		log.Fatal(err)
+	}
+	c.current.Store(snapshot)
 
 	return c
 }
@@ -514,55 +506,31 @@ func validateClientConfig(clientName string, client *domain.Client) error {
 	return nil
 }
 
-func (c *AppConfig) defaults() {
-	// Set default values
-	c.Config.DisableConfigFile = false
-	c.Config.Host = "0.0.0.0"
-	c.Config.Port = 42069
-	c.Config.Clients = make(map[string]*domain.Client)
-	c.Config.LogPath = ""
-	c.Config.LogLevel = "DEBUG"
-	c.Config.LogMaxSize = 50
-	c.Config.LogMaxBackups = 3
-	c.Config.SmartMode = false
-	c.Config.SmartModeThreshold = 0.75
-	c.Config.FuzzyMatching = domain.FuzzyMatching{
-		SkipRepackCompare:  false,
-		SimplifyHdrCompare: false,
-		SimplifyWebCompare: false,
-	}
-	c.Config.Metadata = domain.Metadata{
-		TVDBAPIKey: "",
-		TVDBPIN:    "",
-		// SonarrHost:   "",
-		// SonarrPort:   0,
-		// SonarrAPIKey: "",
-	}
-	c.Config.APIToken = ""
-	c.Config.Notifications = domain.Notifications{
-		NotificationLevel: []string{"MATCH", "ERROR"},
-		Discord:           "",
+func defaultConfig(version, configFile string, disableConfigFile bool) domain.Config {
+	configPath := ""
+	if configFile != "" {
+		configPath = filepath.Dir(configFile)
 	}
 
-	// load default values into koanf
-	if err := c.k.Load(structs.Provider(c.Config, "yaml"), nil); err != nil {
-		log.Fatalf("could not load default values into config: %q", err)
+	return domain.Config{
+		Version:            version,
+		ConfigPath:         configPath,
+		DisableConfigFile:  disableConfigFile,
+		Host:               "0.0.0.0",
+		Port:               42069,
+		Clients:            make(map[string]*domain.Client),
+		LogLevel:           "DEBUG",
+		LogMaxSize:         50,
+		LogMaxBackups:      3,
+		SmartModeThreshold: 0.75,
+		Notifications: domain.Notifications{
+			NotificationLevel: []string{"MATCH", "ERROR"},
+		},
 	}
 }
 
-func (c *AppConfig) loadFromEnv() {
-	prefix := "SEASONPACKARR__"
-
-	logLevel := c.Config.LogLevel
-	if envLogLevel := os.Getenv(prefix + "LOG_LEVEL"); envLogLevel != "" {
-		logLevel = envLogLevel
-	}
-
-	// create a temporary logger with the detected log level
-	zLog := logger.New(&domain.Config{
-		LogLevel: logLevel,
-		Version:  c.Config.Version,
-	})
+func applyEnvironment(cfg *domain.Config) {
+	const prefix = "SEASONPACKARR__"
 
 	envs := os.Environ()
 	for _, env := range envs {
@@ -570,92 +538,79 @@ func (c *AppConfig) loadFromEnv() {
 			envPair := strings.SplitN(env, "=", 2)
 			envKey, envValue := envPair[0], envPair[1]
 
-			// Determine if this is a sensitive value that should be redacted in logs
-			sensitiveKeys := []string{"PASSWORD", "API_TOKEN", "APIKEY", "DISCORD"}
-			logValue := envValue
-
-			for _, sensitive := range sensitiveKeys {
-				if strings.Contains(envKey, sensitive) {
-					logValue = "**REDACTED**"
-					break
-				}
-			}
-
-			zLog.Trace().Msgf("processing environment variable: %s=%s", envKey, logValue)
-
 			if envValue != "" {
 				switch envKey {
 				// disable config file
 				case prefix + "DISABLE_CONFIG_FILE":
 					if b, err := strconv.ParseBool(envValue); err == nil {
-						c.Config.DisableConfigFile = b
+						cfg.DisableConfigFile = b
 					}
 
 				// server settings
 				case prefix + "HOST":
-					c.Config.Host = envValue
+					cfg.Host = envValue
 				case prefix + "PORT":
 					if i, _ := strconv.ParseInt(envValue, 10, 32); i > 0 {
-						c.Config.Port = int(i)
+						cfg.Port = int(i)
 					}
 
 				// log settings
 				case prefix + "LOG_LEVEL":
-					c.Config.LogLevel = envValue
+					cfg.LogLevel = envValue
 				case prefix + "LOG_PATH":
-					c.Config.LogPath = envValue
+					cfg.LogPath = envValue
 				case prefix + "LOG_MAX_SIZE":
 					if i, _ := strconv.ParseInt(envValue, 10, 32); i > 0 {
-						c.Config.LogMaxSize = int(i)
+						cfg.LogMaxSize = int(i)
 					}
 				case prefix + "LOG_MAX_BACKUPS":
 					if i, _ := strconv.ParseInt(envValue, 10, 32); i > 0 {
-						c.Config.LogMaxBackups = int(i)
+						cfg.LogMaxBackups = int(i)
 					}
 
 				// smart mode settings
 				case prefix + "SMART_MODE":
 					if b, err := strconv.ParseBool(envValue); err == nil {
-						c.Config.SmartMode = b
+						cfg.SmartMode = b
 					}
 				case prefix + "SMART_MODE_THRESHOLD":
 					if f, _ := strconv.ParseFloat(envValue, 32); f > 0 {
-						c.Config.SmartModeThreshold = float32(f)
+						cfg.SmartModeThreshold = float32(f)
 					}
 
 				// api token
 				case prefix + "API_TOKEN":
-					c.Config.APIToken = envValue
+					cfg.APIToken = envValue
 
 				// fuzzy matching settings
 				case prefix + "FUZZY_MATCHING_SKIP_REPACK_COMPARE":
 					if b, err := strconv.ParseBool(envValue); err == nil {
-						c.Config.FuzzyMatching.SkipRepackCompare = b
+						cfg.FuzzyMatching.SkipRepackCompare = b
 					}
 				case prefix + "FUZZY_MATCHING_SIMPLIFY_HDR_COMPARE":
 					if b, err := strconv.ParseBool(envValue); err == nil {
-						c.Config.FuzzyMatching.SimplifyHdrCompare = b
+						cfg.FuzzyMatching.SimplifyHdrCompare = b
 					}
 				case prefix + "FUZZY_MATCHING_SIMPLIFY_WEB_COMPARE":
 					if b, err := strconv.ParseBool(envValue); err == nil {
-						c.Config.FuzzyMatching.SimplifyWebCompare = b
+						cfg.FuzzyMatching.SimplifyWebCompare = b
 					}
 
 				// metadata settings
 				case prefix + "METADATA_TVDB_API_KEY":
-					c.Config.Metadata.TVDBAPIKey = envValue
+					cfg.Metadata.TVDBAPIKey = envValue
 				case prefix + "METADATA_TVDB_PIN":
-					c.Config.Metadata.TVDBPIN = envValue
+					cfg.Metadata.TVDBPIN = envValue
 
 				// notifications settings
 				case prefix + "NOTIFICATIONS_DISCORD":
-					c.Config.Notifications.Discord = envValue
+					cfg.Notifications.Discord = envValue
 				case prefix + "NOTIFICATIONS_NOTIFICATION_LEVEL":
 					levels := strings.Split(envValue, ",")
 					for i, level := range levels {
 						levels[i] = strings.TrimSpace(level)
 					}
-					c.Config.Notifications.NotificationLevel = levels
+					cfg.Notifications.NotificationLevel = levels
 				}
 
 				// client settings
@@ -671,38 +626,38 @@ func (c *AppConfig) loadFromEnv() {
 					clientName = strings.ToLower(clientName)
 
 					// initialize client if it doesn't exist
-					if c.Config.Clients[clientName] == nil {
-						c.Config.Clients[clientName] = &domain.Client{}
+					if cfg.Clients[clientName] == nil {
+						cfg.Clients[clientName] = &domain.Client{}
 					}
 
 					switch setting {
 					case "TYPE":
-						c.Config.Clients[clientName].Type = envValue
+						cfg.Clients[clientName].Type = envValue
 					case "HOST":
-						c.Config.Clients[clientName].Host = envValue
+						cfg.Clients[clientName].Host = envValue
 					case "PORT":
 						if i, _ := strconv.ParseInt(envValue, 10, 32); i > 0 {
-							c.Config.Clients[clientName].Port = int(i)
+							cfg.Clients[clientName].Port = int(i)
 						}
 					case "USERNAME":
-						c.Config.Clients[clientName].Username = envValue
+						cfg.Clients[clientName].Username = envValue
 					case "PASSWORD":
-						c.Config.Clients[clientName].Password = envValue
+						cfg.Clients[clientName].Password = envValue
 					case "APIKEY":
-						c.Config.Clients[clientName].APIKey = envValue
+						cfg.Clients[clientName].APIKey = envValue
 					case "IMPORT_SAVE_PATH":
-						c.Config.Clients[clientName].Import.SavePath = envValue
+						cfg.Clients[clientName].Import.SavePath = envValue
 					case "IMPORT_CATEGORY":
-						c.Config.Clients[clientName].Import.Category = envValue
+						cfg.Clients[clientName].Import.Category = envValue
 					case "IMPORT_DOWNLOAD_PATH":
-						c.Config.Clients[clientName].Import.DownloadPath = envValue
+						cfg.Clients[clientName].Import.DownloadPath = envValue
 					case "IMPORT_CONTENT_LAYOUT":
-						c.Config.Clients[clientName].Import.ContentLayout = strings.ToLower(envValue)
+						cfg.Clients[clientName].Import.ContentLayout = strings.ToLower(envValue)
 					case "IMPORT_TAGS":
-						c.Config.Clients[clientName].Import.Tags = c.Config.Clients[clientName].Import.Tags[:0]
+						cfg.Clients[clientName].Import.Tags = cfg.Clients[clientName].Import.Tags[:0]
 						for tag := range strings.SplitSeq(envValue, ",") {
 							if tag = strings.TrimSpace(tag); tag != "" {
-								c.Config.Clients[clientName].Import.Tags = append(c.Config.Clients[clientName].Import.Tags, tag)
+								cfg.Clients[clientName].Import.Tags = append(cfg.Clients[clientName].Import.Tags, tag)
 							}
 						}
 					}
@@ -710,108 +665,138 @@ func (c *AppConfig) loadFromEnv() {
 			}
 		}
 	}
-
-	// load parsed env variables into koanf
-	if err := c.k.Load(structs.Provider(c.Config, "yaml"), nil); err != nil {
-		log.Fatalf("could not load env vars into config: %q", err)
-	}
 }
 
-func (c *AppConfig) load() {
-	// clean trailing slash from c.Config.ConfigPath
-	configPath := path.Clean(c.Config.ConfigPath)
-
-	var configFile string
-
+func (c *AppConfig) resolveConfigFile(configPath string) (string, error) {
 	if configPath != "" {
-		// check if path and file exists
-		// if not, create path and file
+		configPath = filepath.Clean(configPath)
 		if err := c.writeConfig(configPath, "config.yaml"); err != nil {
-			log.Printf("config write error: %q", err)
+			return "", fmt.Errorf("writing config file: %w", err)
 		}
+		return filepath.Join(configPath, "config.yaml"), nil
+	}
 
-		configFile = path.Join(configPath, "config.yaml")
-	} else {
-		// try to find config in standard locations
-		locations := []string{
-			"./config.yaml",
-			"$HOME/.config/seasonpackarr/config.yaml",
-			"$HOME/.seasonpackarr/config.yaml",
-		}
-
-		for _, loc := range locations {
-			expandedLoc := os.ExpandEnv(loc)
-			if _, err := os.Stat(expandedLoc); err == nil {
-				configFile = expandedLoc
-				break
-			}
-		}
-
-		if configFile == "" {
-			log.Fatalf("could not find config file")
+	locations := []string{
+		"./config.yaml",
+		"$HOME/.config/seasonpackarr/config.yaml",
+		"$HOME/.seasonpackarr/config.yaml",
+	}
+	for _, location := range locations {
+		configFile := os.ExpandEnv(location)
+		if info, err := os.Stat(configFile); err == nil && !info.IsDir() {
+			return configFile, nil
 		}
 	}
 
-	// load the config file
-	if err := c.k.Load(file.Provider(configFile), yaml.Parser()); err != nil {
-		log.Fatalf("config read error: %q", err)
-	}
-
-	// unmarshal the config into the Config struct
-	if err := c.k.Unmarshal("", c.Config); err != nil {
-		log.Fatalf("could not unmarshal config file: %v: err %q", configFile, err)
-	}
+	return "", fmt.Errorf("could not find config file")
 }
 
-func (c *AppConfig) DynamicReload(log logger.Logger) {
-	if c.Config.DisableConfigFile {
-		return
+func (c *AppConfig) loadSnapshot() (*domain.Config, error) {
+	cfg := defaultConfig(c.version, c.configFile, c.disableConfigFile)
+	k := koanf.New(".")
+	if err := k.Load(structs.Provider(&cfg, "yaml"), nil); err != nil {
+		return nil, fmt.Errorf("loading config defaults: %w", err)
 	}
 
-	configFile := path.Join(c.Config.ConfigPath, "config.yaml")
+	if !c.disableConfigFile {
+		if err := k.Load(file.Provider(c.configFile), yaml.Parser()); err != nil {
+			return nil, fmt.Errorf("reading config file %s: %w", c.configFile, err)
+		}
+	}
+	if err := validateDeprecatedConfigInputs(k, os.LookupEnv); err != nil {
+		return nil, fmt.Errorf("validating config file %s: %w", c.configFile, err)
+	}
+	if err := k.Unmarshal("", &cfg); err != nil {
+		return nil, fmt.Errorf("decoding config file %s: %w", c.configFile, err)
+	}
+
+	applyEnvironment(&cfg)
+	if err := validateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("validating config file %s: %w", c.configFile, err)
+	}
+
+	snapshot := cloneConfig(cfg)
+	return &snapshot, nil
+}
+
+func validateConfig(cfg domain.Config) error {
+	for clientName, client := range cfg.Clients {
+		if client == nil {
+			return fmt.Errorf("client %q cannot be null", clientName)
+		}
+		if err := validateClientConfig(clientName, client); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cloneConfig(cfg domain.Config) domain.Config {
+	clone := cfg
+	clone.Clients = make(map[string]*domain.Client, len(cfg.Clients))
+	for name, client := range cfg.Clients {
+		if client == nil {
+			clone.Clients[name] = nil
+			continue
+		}
+		clientClone := *client
+		clientClone.Import.Tags = slices.Clone(client.Import.Tags)
+		clone.Clients[name] = &clientClone
+	}
+	clone.Notifications.NotificationLevel = slices.Clone(cfg.Notifications.NotificationLevel)
+	return clone
+}
+
+func (c *AppConfig) Snapshot() domain.Config {
+	snapshot := c.current.Load()
+	if snapshot == nil {
+		return domain.Config{}
+	}
+	return cloneConfig(*snapshot)
+}
+
+func (c *AppConfig) reload() (*domain.Config, error) {
+	snapshot, err := c.loadSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	c.current.Store(snapshot)
+	return snapshot, nil
+}
+
+func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
+	if c.disableConfigFile {
+		return nil, nil
+	}
 
 	// use koanf's built-in file watcher
-	f := file.Provider(configFile)
+	f := file.Provider(c.configFile)
+	reloaded := make(chan struct{}, 1)
 
 	// watch the config file for changes
-	f.Watch(func(event any, err error) {
+	err := f.Watch(func(_ any, watchErr error) {
+		if watchErr != nil {
+			log.Error().Err(watchErr).Msg("error watching config file")
+			return
+		}
+
+		snapshot, err := c.reload()
 		if err != nil {
-			log.Error().Err(err).Msg("error watching config file")
+			log.Error().Err(err).Msg("config reload rejected; keeping previous config")
 			return
 		}
 
-		c.m.Lock()
-		defer c.m.Unlock()
-
-		// create a new koanf instance for reloading
-		k := koanf.New(".")
-
-		// load the config file
-		if err := k.Load(f, yaml.Parser()); err != nil {
-			log.Error().Err(err).Msg("failed to reload config file")
-			return
+		log.SetLogLevel(snapshot.LogLevel)
+		select {
+		case reloaded <- struct{}{}:
+		default:
 		}
-
-		// refuse to apply a reload that still uses removed settings
-		if err := validateDeprecatedConfigInputs(k, os.LookupEnv); err != nil {
-			log.Error().Err(err).Msg("reloaded config uses a removed setting; keeping previous config")
-			return
-		}
-
-		// unmarshal the updated config into the Config struct
-		if err := k.Unmarshal("", c.Config); err != nil {
-			log.Error().Err(err).Msg("failed to unmarshal updated config")
-			return
-		}
-
-		for clientName, client := range c.Config.Clients {
-			if err := validateClientConfig(clientName, client); err != nil {
-				log.Error().Err(err).Msg("reloaded config is invalid; check the client import policy")
-			}
-		}
-
-		log.SetLogLevel(c.Config.LogLevel)
-
-		log.Debug().Msg("config file reloaded!")
+		log.Debug().Msg("config file reloaded")
 	})
+	if err != nil {
+		return nil, fmt.Errorf("watching config file %s: %w", c.configFile, err)
+	}
+	c.watcher = f
+
+	return reloaded, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -259,10 +260,19 @@ clients:
 		require.NoError(t, cfg.watcher.Unwatch())
 	})
 
-	done := make(chan struct{})
+	readerResult := make(chan error, 1)
 	go func() {
-		defer close(done)
-		for cfg.Snapshot().Clients["default"].Import.Category != "after" {
+		for {
+			snapshot := cfg.Snapshot()
+			client, ok := snapshot.Clients["default"]
+			if !ok || client == nil {
+				readerResult <- fmt.Errorf("published snapshot has no default client")
+				return
+			}
+			if client.Import.Category == "after" {
+				readerResult <- nil
+				return
+			}
 		}
 	}()
 
@@ -280,9 +290,66 @@ logLevel: INFO
 		t.Fatal("timed out waiting for config reload")
 	}
 	select {
-	case <-done:
+	case err := <-readerResult:
+		require.NoError(t, err)
 	case <-time.After(3 * time.Second):
 		t.Fatal("concurrent snapshot reader did not observe reload")
+	}
+	require.Equal(t, "after", cfg.Snapshot().Clients["default"].Import.Category)
+}
+
+func TestDynamicReloadKeepsSnapshotWhileConfigWriteIsIncomplete(t *testing.T) {
+	previousLogLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(previousLogLevel)
+	})
+
+	cfg, configFile := newTestAppConfig(t, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: before
+`)
+	snapshot := cfg.Snapshot()
+	reloads, err := cfg.DynamicReload(logger.New(&snapshot))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NotNil(t, cfg.watcher)
+		require.NoError(t, cfg.watcher.Unwatch())
+	})
+
+	configWriter, err := os.OpenFile(configFile, os.O_WRONLY|os.O_TRUNC, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = configWriter.Close()
+	})
+
+	select {
+	case <-reloads:
+		t.Fatal("published a reload while the config file was empty")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	before := cfg.Snapshot()
+	require.Contains(t, before.Clients, "default")
+	require.NotNil(t, before.Clients["default"])
+	require.Equal(t, "before", before.Clients["default"].Import.Category)
+
+	_, err = configWriter.WriteString(`
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: after
+`)
+	require.NoError(t, err)
+	require.NoError(t, configWriter.Close())
+
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for completed config reload")
 	}
 	require.Equal(t, "after", cfg.Snapshot().Clients["default"].Import.Category)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,46 +7,43 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
 	"github.com/nuxencs/seasonpackarr/internal/domain"
+	"github.com/nuxencs/seasonpackarr/internal/logger"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMissingOptionalConfigKeysUseDefaults(t *testing.T) {
-	cfg := &AppConfig{
-		Config: &domain.Config{},
-		k:      koanf.New("."),
-	}
-	cfg.defaults()
-
 	configFile := writeTestConfig(t, `
 host: "127.0.0.1"
 port: 42069
 clients: {}
 logLevel: "INFO"
 `)
+	cfg := &AppConfig{configFile: configFile, version: "test"}
+	snapshot, err := cfg.loadSnapshot()
+	require.NoError(t, err)
 
-	require.NoError(t, cfg.k.Load(file.Provider(configFile), yaml.Parser()))
-	require.NoError(t, cfg.k.Unmarshal("", cfg.Config))
-
-	require.Equal(t, "INFO", cfg.Config.LogLevel)
-	require.Equal(t, "", cfg.Config.LogPath)
-	require.Equal(t, 50, cfg.Config.LogMaxSize)
-	require.Equal(t, 3, cfg.Config.LogMaxBackups)
-	require.False(t, cfg.Config.SmartMode)
-	require.Equal(t, float32(0.75), cfg.Config.SmartModeThreshold)
-	require.False(t, cfg.Config.FuzzyMatching.SkipRepackCompare)
-	require.False(t, cfg.Config.FuzzyMatching.SimplifyHdrCompare)
-	require.False(t, cfg.Config.FuzzyMatching.SimplifyWebCompare)
-	require.False(t, cfg.Config.FuzzyMatching.SkipYearCompare)
-	require.Equal(t, "", cfg.Config.Metadata.TVDBAPIKey)
-	require.Equal(t, "", cfg.Config.Metadata.TVDBPIN)
-	require.Equal(t, "", cfg.Config.APIToken)
-	require.Equal(t, []string{"MATCH", "ERROR"}, cfg.Config.Notifications.NotificationLevel)
-	require.Equal(t, "", cfg.Config.Notifications.Discord)
+	require.Equal(t, "INFO", snapshot.LogLevel)
+	require.Equal(t, "", snapshot.LogPath)
+	require.Equal(t, 50, snapshot.LogMaxSize)
+	require.Equal(t, 3, snapshot.LogMaxBackups)
+	require.False(t, snapshot.SmartMode)
+	require.Equal(t, float32(0.75), snapshot.SmartModeThreshold)
+	require.False(t, snapshot.FuzzyMatching.SkipRepackCompare)
+	require.False(t, snapshot.FuzzyMatching.SimplifyHdrCompare)
+	require.False(t, snapshot.FuzzyMatching.SimplifyWebCompare)
+	require.False(t, snapshot.FuzzyMatching.SkipYearCompare)
+	require.Equal(t, "", snapshot.Metadata.TVDBAPIKey)
+	require.Equal(t, "", snapshot.Metadata.TVDBPIN)
+	require.Equal(t, "", snapshot.APIToken)
+	require.Equal(t, []string{"MATCH", "ERROR"}, snapshot.Notifications.NotificationLevel)
+	require.Equal(t, "", snapshot.Notifications.Discord)
 }
 
 func writeTestConfig(t *testing.T, content string) string {
@@ -117,18 +114,192 @@ func TestLoadFromEnvParsesMultiWordClientSettings(t *testing.T) {
 	t.Setenv("SEASONPACKARR__CLIENTS_ENVONLY_IMPORT_CATEGORY", "tv-hd")
 	t.Setenv("SEASONPACKARR__CLIENTS_ENVONLY_IMPORT_TAGS", "a, b")
 
-	cfg := &AppConfig{
-		Config: &domain.Config{Clients: map[string]*domain.Client{}},
-		k:      koanf.New("."),
-	}
-	cfg.loadFromEnv()
+	cfg := domain.Config{Clients: map[string]*domain.Client{}}
+	applyEnvironment(&cfg)
 
-	client, ok := cfg.Config.Clients["envonly"]
+	client, ok := cfg.Clients["envonly"]
 	require.True(t, ok, "env-only client should be lazily created")
 	require.Equal(t, "qbittorrent", client.Type)
 	require.Equal(t, "/data/tv-hd", client.Import.SavePath)
 	require.Equal(t, "tv-hd", client.Import.Category)
 	require.Equal(t, []string{"a", "b"}, client.Import.Tags)
+}
+
+func TestReloadRejectsInvalidConfigAndKeepsLastSnapshot(t *testing.T) {
+	previousLogLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(previousLogLevel)
+	})
+
+	cfg, configFile := newTestAppConfig(t, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: tv-hd
+logLevel: INFO
+`)
+	before := cfg.Snapshot()
+
+	writeConfigFile(t, configFile, `
+clients:
+  default:
+    type: transmission
+    import:
+      category: tv-hd
+logLevel: TRACE
+`)
+	_, err := cfg.reload()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "qBittorrent only")
+	require.Equal(t, before, cfg.Snapshot())
+	require.Equal(t, zerolog.WarnLevel, zerolog.GlobalLevel())
+}
+
+func TestReloadReappliesEnvironmentOverrides(t *testing.T) {
+	t.Setenv("SEASONPACKARR__CLIENTS_DEFAULT_IMPORT_CATEGORY", "from-env")
+	cfg, configFile := newTestAppConfig(t, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: from-file-before
+`)
+	require.Equal(t, "from-env", cfg.Snapshot().Clients["default"].Import.Category)
+
+	writeConfigFile(t, configFile, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: from-file-after
+`)
+	_, err := cfg.reload()
+	require.NoError(t, err)
+	require.Equal(t, "from-env", cfg.Snapshot().Clients["default"].Import.Category)
+}
+
+func TestReloadRestoresDefaultsForOmittedKeys(t *testing.T) {
+	cfg, configFile := newTestAppConfig(t, `
+clients: {}
+logMaxSize: 99
+`)
+	require.Equal(t, 99, cfg.Snapshot().LogMaxSize)
+
+	writeConfigFile(t, configFile, "clients: {}\n")
+	_, err := cfg.reload()
+	require.NoError(t, err)
+	require.Equal(t, 50, cfg.Snapshot().LogMaxSize)
+}
+
+func TestResolveConfigFileReturnsDiscoveredFile(t *testing.T) {
+	originalWorkingDir, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(originalWorkingDir))
+	})
+
+	workingDir := t.TempDir()
+	homeDir := t.TempDir()
+	configFile := filepath.Join(homeDir, ".config", "seasonpackarr", "config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configFile), 0o755))
+	writeConfigFile(t, configFile, "clients: {}\n")
+	require.NoError(t, os.Chdir(workingDir))
+	t.Setenv("HOME", homeDir)
+
+	cfg := &AppConfig{}
+	got, err := cfg.resolveConfigFile("")
+	require.NoError(t, err)
+	require.Equal(t, configFile, got)
+}
+
+func TestSnapshotCannotMutateStoredConfig(t *testing.T) {
+	cfg, _ := newTestAppConfig(t, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: tv-hd
+      tags: [one, two]
+notifications:
+  notificationLevel: [MATCH, ERROR]
+`)
+
+	snapshot := cfg.Snapshot()
+	snapshot.Clients["default"].Import.Category = "changed"
+	snapshot.Clients["default"].Import.Tags[0] = "changed"
+	snapshot.Notifications.NotificationLevel[0] = "changed"
+	delete(snapshot.Clients, "default")
+
+	stored := cfg.Snapshot()
+	require.Equal(t, "tv-hd", stored.Clients["default"].Import.Category)
+	require.Equal(t, []string{"one", "two"}, stored.Clients["default"].Import.Tags)
+	require.Equal(t, []string{"MATCH", "ERROR"}, stored.Notifications.NotificationLevel)
+}
+
+func TestDynamicReloadPublishesSnapshotForConcurrentReaders(t *testing.T) {
+	previousLogLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(previousLogLevel)
+	})
+
+	cfg, configFile := newTestAppConfig(t, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: before
+`)
+	snapshot := cfg.Snapshot()
+	reloads, err := cfg.DynamicReload(logger.New(&snapshot))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NotNil(t, cfg.watcher)
+		require.NoError(t, cfg.watcher.Unwatch())
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for cfg.Snapshot().Clients["default"].Import.Category != "after" {
+		}
+	}()
+
+	writeConfigFile(t, configFile, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: after
+logLevel: INFO
+`)
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for config reload")
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("concurrent snapshot reader did not observe reload")
+	}
+	require.Equal(t, "after", cfg.Snapshot().Clients["default"].Import.Category)
+}
+
+func newTestAppConfig(t *testing.T, contents string) (*AppConfig, string) {
+	t.Helper()
+	configFile := writeTestConfig(t, contents)
+	cfg := &AppConfig{configFile: configFile, version: "test"}
+	snapshot, err := cfg.loadSnapshot()
+	require.NoError(t, err)
+	cfg.current.Store(snapshot)
+	return cfg, configFile
+}
+
+func writeConfigFile(t *testing.T, configFile, contents string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(configFile, []byte(contents), 0o644))
 }
 
 func TestValidateClientConfig(t *testing.T) {

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -17,22 +17,24 @@ import (
 
 func (s *Server) AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		apiToken := s.cfg.Snapshot().APIToken
+
 		// Allow access if apiToken value is set to an empty string
-		if s.cfg.Config.APIToken == "" {
+		if apiToken == "" {
 			c.Next()
 			return
 		}
 
 		// Check the X-API-Token header
 		if token := c.GetHeader("X-API-Token"); token != "" {
-			if token != s.cfg.Config.APIToken {
+			if token != apiToken {
 				s.log.Error().Msgf("unauthorized access attempt with incorrect API token in header from IP: %s", c.ClientIP())
 				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 				return
 			}
 		} else if key := c.Query("apikey"); key != "" {
 			// Check the query parameter ?apikey=TOKEN
-			if key != s.cfg.Config.APIToken {
+			if key != apiToken {
 				s.log.Error().Msgf("unauthorized access attempt with incorrect API token in query parameters from IP: %s", c.ClientIP())
 				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 				return
@@ -78,7 +80,7 @@ func LoggerMiddleware(logger logger.Logger) gin.HandlerFunc {
 				log.Trace().
 					Str("type", "access").
 					Timestamp().
-					Fields(map[string]interface{}{
+					Fields(map[string]any{
 						"remote_ip":  c.ClientIP(),
 						"url":        c.Request.URL.Path,
 						"proto":      c.Request.Proto,

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	stdslices "slices"
 	"sync"
 	"time"
 
@@ -30,7 +31,7 @@ import (
 
 type processor struct {
 	log  zerolog.Logger
-	cfg  *config.AppConfig
+	cfg  config.Provider
 	noti domain.Sender
 	meta *metadata.Provider
 	req  *request
@@ -49,10 +50,12 @@ type entry struct {
 }
 
 type entryCache struct {
-	entriesMap  map[string][]entry
-	rlsMap      map[string]rls.Release
-	lastUpdated time.Time
-	mu          sync.Mutex
+	entriesMap    map[string][]entry
+	rlsMap        map[string]rls.Release
+	clientConfig  domain.Client
+	fuzzyMatching domain.FuzzyMatching
+	lastUpdated   time.Time
+	mu            sync.Mutex
 }
 
 type matchInfo struct {
@@ -60,12 +63,17 @@ type matchInfo struct {
 	clientEpSize int64
 }
 
+type cachedTorrentClient struct {
+	config domain.Client
+	client torrentclient.TorrentClient
+}
+
 var (
-	clientMap = xsync.NewMapOf[string, torrentclient.TorrentClient]()
+	clientMap = xsync.NewMapOf[string, cachedTorrentClient]()
 	entryMap  = xsync.NewMapOf[string, *entryCache]()
 )
 
-func newProcessor(log logger.Logger, config *config.AppConfig, notification domain.Sender, metadata *metadata.Provider) *processor {
+func newProcessor(log logger.Logger, config config.Provider, notification domain.Sender, metadata *metadata.Provider) *processor {
 	return &processor{
 		log:  log.With().Str("module", "processor").Logger(),
 		cfg:  config,
@@ -80,29 +88,56 @@ func (p *processor) getClient(client *domain.Client, clientName string) error {
 		return nil
 	}
 
-	c, ok := clientMap.Load(clientName)
-	if !ok {
-		var err error
-		c, err = torrentclient.New(client)
-		if err != nil {
-			return errors.Wrap(err, "failed to create torrent client")
-		}
-
-		clientMap.Store(clientName, c)
+	if cached, ok := clientMap.Load(clientName); ok && clientConfigsEqual(cached.config, *client) {
+		p.req.Client = cached.client
+		return nil
 	}
 
+	c, err := torrentclient.New(client)
+	if err != nil {
+		return errors.Wrap(err, "failed to create torrent client")
+	}
+
+	clientMap.Store(clientName, cachedTorrentClient{
+		config: cloneClientConfig(*client),
+		client: c,
+	})
 	p.req.Client = c
 	return nil
 }
 
-func (p *processor) getAllTorrents(clientName string) (map[string][]entry, error) {
+func cloneClientConfig(client domain.Client) domain.Client {
+	clone := client
+	clone.Import.Tags = stdslices.Clone(client.Import.Tags)
+	return clone
+}
+
+func clientConfigsEqual(a, b domain.Client) bool {
+	return a.Type == b.Type &&
+		a.Host == b.Host &&
+		a.Port == b.Port &&
+		a.Username == b.Username &&
+		a.Password == b.Password &&
+		a.APIKey == b.APIKey &&
+		a.Import.SavePath == b.Import.SavePath &&
+		stdslices.Equal(a.Import.Tags, b.Import.Tags) &&
+		a.Import.Category == b.Import.Category &&
+		a.Import.DownloadPath == b.Import.DownloadPath &&
+		a.Import.ContentLayout == b.Import.ContentLayout
+}
+
+func (p *processor) getAllTorrents(clientName string, clientConfig *domain.Client, fuzzyMatching domain.FuzzyMatching) (map[string][]entry, error) {
 	f := func() *entryCache {
 		tre, ok := entryMap.Load(clientName)
-		if ok {
+		if ok && clientConfigsEqual(tre.clientConfig, *clientConfig) && tre.fuzzyMatching == fuzzyMatching {
 			return tre
 		}
 
-		entries := &entryCache{rlsMap: make(map[string]rls.Release)}
+		entries := &entryCache{
+			rlsMap:        make(map[string]rls.Release),
+			clientConfig:  cloneClientConfig(*clientConfig),
+			fuzzyMatching: fuzzyMatching,
+		}
 		entryMap.Store(clientName, entries)
 		return entries
 	}
@@ -116,7 +151,6 @@ func (p *processor) getAllTorrents(clientName string) (map[string][]entry, error
 	entries.mu.Lock()
 	defer entries.mu.Unlock()
 
-	entries = f()
 	if entries.lastUpdated.After(cur) {
 		return entries.entriesMap, nil
 	}
@@ -127,21 +161,32 @@ func (p *processor) getAllTorrents(clientName string) (map[string][]entry, error
 	}
 
 	after := time.Now()
-	entries = &entryCache{entriesMap: make(map[string][]entry), lastUpdated: after.Add(after.Sub(cur)), rlsMap: entries.rlsMap}
-
-	for _, t := range ts {
-		r, ok := entries.rlsMap[t.Name]
-		if !ok {
-			r = rls.ParseString(t.Name)
-			entries.rlsMap[t.Name] = r
-		}
-
-		comparableTitle := format.ComparableTitle(r, p.cfg.Config.FuzzyMatching)
-		entries.entriesMap[comparableTitle] = append(entries.entriesMap[comparableTitle], entry{torrent: t, release: r})
+	refreshed := &entryCache{
+		entriesMap:    make(map[string][]entry),
+		rlsMap:        entries.rlsMap,
+		clientConfig:  cloneClientConfig(*clientConfig),
+		fuzzyMatching: fuzzyMatching,
+		lastUpdated:   after.Add(after.Sub(cur)),
 	}
 
-	entryMap.Store(clientName, entries)
-	return entries.entriesMap, nil
+	for _, t := range ts {
+		r, ok := refreshed.rlsMap[t.Name]
+		if !ok {
+			r = rls.ParseString(t.Name)
+			refreshed.rlsMap[t.Name] = r
+		}
+
+		comparableTitle := format.ComparableTitle(r, fuzzyMatching)
+		refreshed.entriesMap[comparableTitle] = append(refreshed.entriesMap[comparableTitle], entry{torrent: t, release: r})
+	}
+
+	entryMap.Compute(clientName, func(current *entryCache, loaded bool) (*entryCache, bool) {
+		if loaded && current != entries {
+			return current, false
+		}
+		return refreshed, false
+	})
+	return refreshed.entriesMap, nil
 }
 
 func (p *processor) getFiles(hash string) (string, int64, error) {
@@ -234,18 +279,19 @@ func (p *processor) ProcessSeasonPackHandler(c *gin.Context) {
 // effects - hardlinking and importing happen on /api/parse.
 func (p *processor) processSeasonPack() (domain.StatusCode, error) {
 	clientName := p.getClientName()
+	snapshot := p.cfg.Snapshot()
 
 	p.log.UpdateContext(func(c zerolog.Context) zerolog.Context {
 		return c.Str("release", p.req.Name).Str("clientname", clientName)
 	})
 
-	clientCfg, ok := p.cfg.Config.Clients[clientName]
+	clientCfg, ok := snapshot.Clients[clientName]
 	if !ok {
 		return domain.StatusClientNotFound, domain.StatusClientNotFound.Error()
 	}
 	p.log.Info().Msgf("using %s client", clientName)
 
-	if _, statusCode, err := p.collectMatches(clientName, clientCfg); err != nil {
+	if _, statusCode, err := p.collectMatches(clientName, clientCfg, snapshot); err != nil {
 		return statusCode, err
 	}
 
@@ -255,7 +301,7 @@ func (p *processor) processSeasonPack() (domain.StatusCode, error) {
 // collectMatches resolves the announced release against the episodes currently
 // in the client and returns the deduped set of matched client episodes. It is
 // shared by /api/pack (gate) and /api/parse (import) so the two never disagree.
-func (p *processor) collectMatches(clientName string, clientCfg *domain.Client) ([]matchInfo, domain.StatusCode, error) {
+func (p *processor) collectMatches(clientName string, clientCfg *domain.Client, cfg domain.Config) ([]matchInfo, domain.StatusCode, error) {
 	if len(p.req.Name) == 0 {
 		return nil, domain.StatusAnnounceNameError, domain.StatusAnnounceNameError.Error()
 	}
@@ -264,20 +310,20 @@ func (p *processor) collectMatches(clientName string, clientCfg *domain.Client) 
 		return nil, domain.StatusGetClientError, fmt.Errorf("%s: %w", domain.StatusGetClientError, err)
 	}
 
-	entries, err := p.getAllTorrents(clientName)
+	entries, err := p.getAllTorrents(clientName, clientCfg, cfg.FuzzyMatching)
 	if err != nil {
 		return nil, domain.StatusGetTorrentsError, fmt.Errorf("%s: %w", domain.StatusGetTorrentsError, err)
 	}
 
 	requestRls := rls.ParseString(p.req.Name)
-	filteredEntries, ok := entries[format.ComparableTitle(requestRls, p.cfg.Config.FuzzyMatching)]
+	filteredEntries, ok := entries[format.ComparableTitle(requestRls, cfg.FuzzyMatching)]
 	if !ok {
 		return nil, domain.StatusNoMatches, domain.StatusNoMatches.Error()
 	}
 
 	comparisons := make([]domain.CompareInfo, len(filteredEntries))
 	for i, filteredEntry := range filteredEntries {
-		compareInfo := release.CheckCandidates(requestRls, filteredEntry.release, p.cfg.Config.FuzzyMatching)
+		compareInfo := release.CheckCandidates(requestRls, filteredEntry.release, cfg.FuzzyMatching)
 		comparisons[i] = compareInfo
 		switch compareInfo.StatusCode {
 		case domain.StatusAlreadyInClient, domain.StatusNotASeasonPack:
@@ -326,7 +372,7 @@ func (p *processor) collectMatches(clientName string, clientCfg *domain.Client) 
 		return nil, domain.StatusNoMatches, domain.StatusNoMatches.Error()
 	}
 
-	if p.cfg.Config.SmartMode {
+	if cfg.SmartMode {
 		totalEps, err := p.meta.EpisodesInSeason(requestRls)
 		if err != nil {
 			return nil, domain.StatusEpisodeCountError, fmt.Errorf("%s: %w", domain.StatusEpisodeCountError, err)
@@ -337,7 +383,7 @@ func (p *processor) collectMatches(clientName string, clientCfg *domain.Client) 
 
 		p.log.Info().Msgf("found %d/%d (%.2f%%) episodes in client", foundEps, totalEps, percentEps*100)
 
-		if percentEps < p.cfg.Config.SmartModeThreshold {
+		if percentEps < cfg.SmartModeThreshold {
 			return nil, domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
 		}
 	}
@@ -397,12 +443,13 @@ func (p *processor) ParseTorrentHandler(c *gin.Context) {
 // folder, then imports the season pack back into the client.
 func (p *processor) parseTorrent() (domain.StatusCode, error) {
 	clientName := p.getClientName()
+	snapshot := p.cfg.Snapshot()
 
 	p.log.UpdateContext(func(c zerolog.Context) zerolog.Context {
 		return c.Str("release", p.req.Name).Str("clientname", clientName)
 	})
 
-	clientCfg, ok := p.cfg.Config.Clients[clientName]
+	clientCfg, ok := snapshot.Clients[clientName]
 	if !ok {
 		return domain.StatusClientNotFound, domain.StatusClientNotFound.Error()
 	}
@@ -424,7 +471,7 @@ func (p *processor) parseTorrent() (domain.StatusCode, error) {
 	importRoot := importDestination.SavePath()
 	p.log.Debug().Msgf("resolved import root: %s", importRoot)
 
-	matches, statusCode, err := p.collectMatches(clientName, clientCfg)
+	matches, statusCode, err := p.collectMatches(clientName, clientCfg, snapshot)
 	if err != nil {
 		return statusCode, err
 	}

--- a/internal/http/processor_test.go
+++ b/internal/http/processor_test.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
-	"github.com/nuxencs/seasonpackarr/internal/config"
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/internal/logger"
 	"github.com/nuxencs/seasonpackarr/internal/torrentclient"
@@ -23,12 +23,13 @@ import (
 // mockTorrentClient is a configurable in-memory torrentclient.TorrentClient for
 // exercising the processor without a live torrent client.
 type mockTorrentClient struct {
-	torrents    []torrentclient.Torrent
-	torrentsErr error
-	files       []torrentclient.File            // returned for any hash when filesByHash is nil
-	filesByHash map[string][]torrentclient.File // per-hash file lists
-	filesErr    error
-	gotHash     string
+	torrents     []torrentclient.Torrent
+	torrentsErr  error
+	torrentCalls int
+	files        []torrentclient.File            // returned for any hash when filesByHash is nil
+	filesByHash  map[string][]torrentclient.File // per-hash file lists
+	filesErr     error
+	gotHash      string
 
 	importRoot    string
 	importRootErr error
@@ -38,7 +39,18 @@ type mockTorrentClient struct {
 	importReq     torrentclient.ImportRequest
 }
 
+type staticConfig struct {
+	config domain.Config
+}
+
+var clientConfigsEqualSink bool
+
+func (c staticConfig) Snapshot() domain.Config {
+	return c.config
+}
+
 func (m *mockTorrentClient) GetTorrents() ([]torrentclient.Torrent, error) {
+	m.torrentCalls++
 	return m.torrents, m.torrentsErr
 }
 
@@ -164,12 +176,89 @@ func TestGetFilesPropagatesClientError(t *testing.T) {
 }
 
 func resetProcessorGlobals() {
-	clientMap = xsync.NewMapOf[string, torrentclient.TorrentClient]()
+	clientMap = xsync.NewMapOf[string, cachedTorrentClient]()
 	entryMap = xsync.NewMapOf[string, *entryCache]()
 }
 
+func TestClientConfigsEqualCoversEveryField(t *testing.T) {
+	base := domain.Client{
+		Type:     "qbittorrent",
+		Host:     "localhost",
+		Port:     8080,
+		Username: "user",
+		Password: "password",
+		APIKey:   "api-key",
+		Import: domain.ImportPolicy{
+			SavePath:      "/save",
+			Tags:          []string{"one", "two"},
+			Category:      "category",
+			DownloadPath:  "/download",
+			ContentLayout: "subfolder",
+		},
+	}
+	require.True(t, clientConfigsEqual(base, cloneClientConfig(base)))
+
+	tests := map[string]func(*domain.Client){
+		"type":           func(client *domain.Client) { client.Type = "transmission" },
+		"host":           func(client *domain.Client) { client.Host = "other" },
+		"port":           func(client *domain.Client) { client.Port++ },
+		"username":       func(client *domain.Client) { client.Username = "other" },
+		"password":       func(client *domain.Client) { client.Password = "other" },
+		"api key":        func(client *domain.Client) { client.APIKey = "other" },
+		"save path":      func(client *domain.Client) { client.Import.SavePath = "/other" },
+		"tags":           func(client *domain.Client) { client.Import.Tags[0] = "other" },
+		"category":       func(client *domain.Client) { client.Import.Category = "other" },
+		"download path":  func(client *domain.Client) { client.Import.DownloadPath = "/other" },
+		"content layout": func(client *domain.Client) { client.Import.ContentLayout = "original" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			changed := cloneClientConfig(base)
+			mutate(&changed)
+			require.False(t, clientConfigsEqual(base, changed))
+		})
+	}
+
+	withoutTags := cloneClientConfig(base)
+	withoutTags.Import.Tags = nil
+	emptyTags := cloneClientConfig(base)
+	emptyTags.Import.Tags = []string{}
+	require.True(t, clientConfigsEqual(withoutTags, emptyTags), "nil and empty tags have the same policy")
+
+	allocations := testing.AllocsPerRun(1000, func() {
+		clientConfigsEqualSink = clientConfigsEqual(base, base)
+	})
+	require.Zero(t, allocations, "config equality is on the request path")
+}
+
+func TestTorrentEntryCacheIsScopedToClientAndFuzzyConfig(t *testing.T) {
+	resetProcessorGlobals()
+	mock := &mockTorrentClient{torrents: []torrentclient.Torrent{{Name: "Series.S01E01.1080p.WEB-DL-GRP"}}}
+	p := newTestProcessor(mock)
+	client := &domain.Client{Type: "qbittorrent", Import: domain.ImportPolicy{Category: "one"}}
+
+	_, err := p.getAllTorrents("default", client, domain.FuzzyMatching{})
+	require.NoError(t, err)
+	cached, ok := entryMap.Load("default")
+	require.True(t, ok)
+	cached.lastUpdated = time.Now().Add(time.Minute)
+	_, err = p.getAllTorrents("default", client, domain.FuzzyMatching{})
+	require.NoError(t, err)
+	require.Equal(t, 1, mock.torrentCalls, "unchanged config should reuse cached entries")
+
+	changedClient := cloneClientConfig(*client)
+	changedClient.Import.Category = "two"
+	_, err = p.getAllTorrents("default", &changedClient, domain.FuzzyMatching{})
+	require.NoError(t, err)
+	require.Equal(t, 2, mock.torrentCalls, "client config change should refresh cached entries")
+
+	_, err = p.getAllTorrents("default", &changedClient, domain.FuzzyMatching{SkipYearCompare: true})
+	require.NoError(t, err)
+	require.Equal(t, 3, mock.torrentCalls, "fuzzy config change should refresh cached entries")
+}
+
 func newImportProcessor() *processor {
-	cfg := &config.AppConfig{Config: &domain.Config{
+	cfg := staticConfig{config: domain.Config{
 		Clients: map[string]*domain.Client{
 			"default": {Type: "qbittorrent", Import: domain.ImportPolicy{Category: "tv-hd"}},
 		},

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -25,14 +25,14 @@ var ErrServerClosed = http.ErrServerClosed
 
 type Server struct {
 	log  logger.Logger
-	cfg  *config.AppConfig
+	cfg  config.Provider
 	noti domain.Sender
 	meta *metadata.Provider
 
 	httpServer http.Server
 }
 
-func NewServer(log logger.Logger, config *config.AppConfig, notification domain.Sender, metadata *metadata.Provider) *Server {
+func NewServer(log logger.Logger, config config.Provider, notification domain.Sender, metadata *metadata.Provider) *Server {
 	return &Server{
 		log:  log,
 		cfg:  config,
@@ -43,7 +43,8 @@ func NewServer(log logger.Logger, config *config.AppConfig, notification domain.
 
 func (s *Server) Open() error {
 	var err error
-	addr := fmt.Sprintf("%s:%d", s.cfg.Config.Host, s.cfg.Config.Port)
+	snapshot := s.cfg.Snapshot()
+	addr := fmt.Sprintf("%s:%d", snapshot.Host, snapshot.Port)
 
 	for _, proto := range []string{"tcp", "tcp4", "tcp6"} {
 		if err = s.tryToServe(addr, proto); err == nil {

--- a/internal/http/webhook.go
+++ b/internal/http/webhook.go
@@ -14,12 +14,12 @@ import (
 
 type webhookHandler struct {
 	log  logger.Logger
-	cfg  *config.AppConfig
+	cfg  config.Provider
 	noti domain.Sender
 	meta *metadata.Provider
 }
 
-func newWebhookHandler(log logger.Logger, cfg *config.AppConfig, notification domain.Sender, metadata *metadata.Provider) *webhookHandler {
+func newWebhookHandler(log logger.Logger, cfg config.Provider, notification domain.Sender, metadata *metadata.Provider) *webhookHandler {
 	return &webhookHandler{
 		log:  log,
 		cfg:  cfg,

--- a/internal/notification/discord.go
+++ b/internal/notification/discord.go
@@ -23,7 +23,7 @@ import (
 )
 
 type DiscordMessage struct {
-	Content interface{}     `json:"content"`
+	Content any             `json:"content"`
 	Embeds  []DiscordEmbeds `json:"embeds,omitempty"`
 }
 
@@ -51,12 +51,12 @@ const (
 
 type discordSender struct {
 	log zerolog.Logger
-	cfg *config.AppConfig
+	cfg config.Provider
 
 	httpClient *http.Client
 }
 
-func NewDiscordSender(log logger.Logger, config *config.AppConfig) domain.Sender {
+func NewDiscordSender(log logger.Logger, config config.Provider) domain.Sender {
 	return &discordSender{
 		log: log.With().Str("sender", "discord").Logger(),
 		cfg: config,
@@ -71,12 +71,13 @@ func (s *discordSender) Name() string {
 }
 
 func (s *discordSender) Send(statusCode domain.StatusCode, payload domain.NotificationPayload) error {
-	if !s.isEnabled() {
+	notifications := s.cfg.Snapshot().Notifications
+	if !s.isEnabled(notifications) {
 		s.log.Debug().Msg("no webhook defined, skipping notification")
 		return nil
 	}
 
-	if !s.shouldSend(statusCode) {
+	if !s.shouldSend(statusCode, notifications) {
 		s.log.Debug().Msg("no notification wanted for this status, skipping notification")
 		return nil
 	}
@@ -91,7 +92,7 @@ func (s *discordSender) Send(statusCode domain.StatusCode, payload domain.Notifi
 		return errors.Wrap(err, "could not marshal json request for status: %v payload: %v", statusCode, payload)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, s.cfg.Config.Notifications.Discord, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest(http.MethodPost, notifications.Discord, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return errors.Wrap(err, "could not create request for status: %v payload: %v", statusCode, payload)
 	}
@@ -123,18 +124,18 @@ func (s *discordSender) Send(statusCode domain.StatusCode, payload domain.Notifi
 	return nil
 }
 
-func (s *discordSender) isEnabled() bool {
-	return len(s.cfg.Config.Notifications.Discord) != 0
+func (s *discordSender) isEnabled(notifications domain.Notifications) bool {
+	return len(notifications.Discord) != 0
 }
 
-func (s *discordSender) shouldSend(statusCode domain.StatusCode) bool {
-	if len(s.cfg.Config.Notifications.NotificationLevel) == 0 {
+func (s *discordSender) shouldSend(statusCode domain.StatusCode, notifications domain.Notifications) bool {
+	if len(notifications.NotificationLevel) == 0 {
 		return false
 	}
 
 	statusCodes := make(map[domain.StatusCode]struct{})
 
-	for _, level := range s.cfg.Config.Notifications.NotificationLevel {
+	for _, level := range notifications.NotificationLevel {
 		if codes, ok := domain.NotificationStatusMap[level]; ok {
 			for _, code := range codes {
 				statusCodes[code] = struct{}{}


### PR DESCRIPTION
## Problem

Config reload decoded YAML directly into the live config before validation. An invalid client config therefore replaced the last valid state even though the service logged a validation error. Reload also dropped environment precedence and raced with request handlers that read the same mutable config.

The watcher derived its path from the original config directory instead of retaining the exact file selected by automatic discovery.

## Fix

Build each candidate from defaults, the complete YAML file, and `SEASONPACKARR__...` environment overrides. Validate the candidate before atomically publishing an immutable snapshot. Rejected reloads have no runtime side effects and keep the last valid snapshot.

Runtime consumers now acquire one coherent snapshot per request or operation. Torrent-client and entry caches are scoped to the client and fuzzy-matching settings, so a valid live reload cannot reuse stale policy or parsed entries. Client comparison uses direct, zero-allocation field checks on the request path.

The operator documentation now identifies live settings and settings that still require a restart.

## Tests

- Regression coverage for invalid reload retention and rejected log-level changes
- Environment precedence, default restoration, discovered file path, and snapshot isolation cases
- Concurrent publication under the race detector
- Client and fuzzy-matching cache invalidation, including zero-allocation config comparison
- Process smoke test for a valid API-token reload followed by an invalid client reload
