### PR TITLE
chore: modernize Go syntax

### DIFF
--- a/internal/slices/slices_test.go
+++ b/internal/slices/slices_test.go
@@ -12,8 +12,8 @@ import (
 func Test_Dedupe(t *testing.T) {
 	tests := []struct {
 		name  string
-		slice interface{}
-		want  interface{}
+		slice any
+		want  any
 	}{
 		{
 			name:  "string_slice_some_duplicates",
@@ -73,8 +73,8 @@ func Test_Dedupe(t *testing.T) {
 func Test_EqualElements(t *testing.T) {
 	tests := []struct {
 		name string
-		x    interface{}
-		y    interface{}
+		x    any
+		y    any
 		want bool
 	}{
 		{

--- a/internal/torrentclient/import_live_test.go
+++ b/internal/torrentclient/import_live_test.go
@@ -207,7 +207,7 @@ func TestQbitImportDestinationPreferencesLive(t *testing.T) {
 		t.Fatalf("get original preferences: %v", err)
 	}
 	t.Cleanup(func() {
-		if err := raw.SetPreferences(map[string]interface{}{
+		if err := raw.SetPreferences(map[string]any{
 			"auto_tmm_enabled":                  original.AutoTmmEnabled,
 			"use_category_paths_in_manual_mode": original.UseCategoryPathsInManualMode,
 			"save_path":                         original.SavePath,
@@ -219,7 +219,7 @@ func TestQbitImportDestinationPreferencesLive(t *testing.T) {
 		}
 	})
 
-	if err := raw.SetPreferences(map[string]interface{}{"save_path": importDir}); err != nil {
+	if err := raw.SetPreferences(map[string]any{"save_path": importDir}); err != nil {
 		t.Fatalf("set default save path: %v", err)
 	}
 	if err := raw.CreateCategory(categoryName, categoryPath); err != nil {
@@ -238,7 +238,7 @@ func TestQbitImportDestinationPreferencesLive(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := raw.SetPreferences(map[string]interface{}{
+			if err := raw.SetPreferences(map[string]any{
 				"auto_tmm_enabled":                  tt.autoTMM,
 				"use_category_paths_in_manual_mode": tt.manualCategoryPath,
 			}); err != nil {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -31,14 +31,14 @@ type StackTracer interface {
 
 // Sentinel is used to create compile-time errors that are intended to be value only, with
 // no associated stack trace.
-func Sentinel(msg string, args ...interface{}) error {
+func Sentinel(msg string, args ...any) error {
 	return fmt.Errorf(msg, args...)
 }
 
 // New acts as pkg/errors.New does, producing a stack traced error, but supports
 // interpolating of message parameters. Use this when you want the stack trace to start at
 // the place you create the error.
-func New(msg string, args ...interface{}) error {
+func New(msg string, args ...any) error {
 	return PopStack(errors.New(fmt.Sprintf(msg, args...)))
 }
 
@@ -48,7 +48,7 @@ func New(msg string, args ...interface{}) error {
 // It differs from the pkg/errors Wrap/Wrapf by idempotently creating a stack trace,
 // meaning we won't create another stack trace when there is already a stack trace present
 // that matches our current program position.
-func Wrap(cause error, msg string, args ...interface{}) error {
+func Wrap(cause error, msg string, args ...any) error {
 	causeStackTracer := new(StackTracer)
 	if errors.As(cause, causeStackTracer) {
 		// If our cause has set a stack trace, and that trace is a child of our own function
@@ -98,7 +98,7 @@ func ancestorOfCause(ourStack []uintptr, causeStack errors.StackTrace) bool {
 	}
 
 	// We know the sizes are compatible, so compare program counters from back to front.
-	for idx := 0; idx < len(ourStack); idx++ {
+	for range ourStack {
 		if ourStack[len(ourStack)-1] != (uintptr)(causeStack[len(causeStack)-1]) {
 			return false
 		}
@@ -125,7 +125,7 @@ func callers(skip int) []uintptr {
 //	    errors.RecoverPanic(recover(), &err)
 //	  }()
 //	}
-func RecoverPanic(r interface{}, errPtr *error) {
+func RecoverPanic(r any, errPtr *error) {
 	var err error
 	if r != nil {
 		if panicErr, ok := r.(error); ok {


### PR DESCRIPTION
## Why

Go 1.26 `go fix` reports legacy syntax in three files. Keeping this cleanup separate avoids mixing mechanical edits with behavior changes.

## What changed

- Replace `interface{}` with `any`.
- Replace an unused numeric loop counter with the equivalent range form.
- Run `gofumpt` and `go mod tidy`; they produce no additional changes.

## Tests

- `go test -v ./...`
- `go test -race ./...`
- `go vet ./...`
- `govulncheck ./...`