### PR TITLE
fix(config): debounce reload event bursts

### DIFF
--- a/docs/product-specs/config-reload.md
+++ b/docs/product-specs/config-reload.md
@@ -43,6 +43,7 @@ These changes require a process restart.
 
 - invalid YAML or invalid client settings keep the last valid config active
 - truncate-first file writes never publish an empty intermediate snapshot
+- one save's filesystem event burst produces one reload attempt
 - environment values keep precedence after every reload
 - omitted optional keys return to built-in defaults
 - concurrent readers do not race with reload publication

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"text/template"
 	"time"
@@ -826,7 +827,7 @@ func (c *AppConfig) reload() (*domain.Config, error) {
 	return snapshot, nil
 }
 
-const configReloadSettleDelay = 10 * time.Millisecond
+const configReloadDebounceDelay = 100 * time.Millisecond
 
 func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 	if c.disableConfigFile {
@@ -836,18 +837,21 @@ func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 	// use koanf's built-in file watcher
 	f := file.Provider(c.configFile)
 	reloaded := make(chan struct{}, 1)
+	var (
+		reloadGeneration atomic.Uint64
+		reloadMu         sync.Mutex
+	)
 
-	// watch the config file for changes
-	err := f.Watch(func(_ any, watchErr error) {
-		if watchErr != nil {
-			log.Error().Err(watchErr).Msg("error watching config file")
+	reloadIfLatest := func(generation uint64) {
+		if generation != reloadGeneration.Load() {
 			return
 		}
 
-		// On Linux, a direct write can emit a truncate event before the new
-		// contents are available. Let the write settle before loading it. Slower
-		// writes remain protected by reload's empty-file check.
-		time.Sleep(configReloadSettleDelay)
+		reloadMu.Lock()
+		defer reloadMu.Unlock()
+		if generation != reloadGeneration.Load() {
+			return
+		}
 
 		snapshot, err := c.reload()
 		if err != nil {
@@ -861,6 +865,27 @@ func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 		default:
 		}
 		log.Debug().Msg("config file reloaded")
+	}
+
+	scheduleReload := func() {
+		generation := reloadGeneration.Add(1)
+		time.AfterFunc(configReloadDebounceDelay, func() {
+			reloadIfLatest(generation)
+		})
+	}
+
+	// watch the config file for changes
+	err := f.Watch(func(_ any, watchErr error) {
+		if watchErr != nil {
+			reloadGeneration.Add(1)
+			log.Error().Err(watchErr).Msg("error watching config file")
+			return
+		}
+
+		// Editors and bind mounts can emit several write events for one save.
+		// Reload after the event burst becomes quiet so truncate-first writes do
+		// not produce a transient rejection or duplicate successful reloads.
+		scheduleReload()
 	})
 	if err != nil {
 		return nil, fmt.Errorf("watching config file %s: %w", c.configFile, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,9 +4,11 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +20,44 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+type synchronizedBuffer struct {
+	mu sync.Mutex
+	bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.Buffer.Write(p)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.Buffer.String()
+}
+
+type captureLogger struct {
+	log zerolog.Logger
+}
+
+func newCaptureLogger(output *synchronizedBuffer) *captureLogger {
+	return &captureLogger{log: zerolog.New(output)}
+}
+
+func (l *captureLogger) Log() *zerolog.Event          { return l.log.Log() }
+func (l *captureLogger) Fatal() *zerolog.Event        { return l.log.Panic() }
+func (l *captureLogger) Err(err error) *zerolog.Event { return l.log.Err(err) }
+func (l *captureLogger) Error() *zerolog.Event        { return l.log.Error() }
+func (l *captureLogger) Warn() *zerolog.Event         { return l.log.Warn() }
+func (l *captureLogger) Info() *zerolog.Event         { return l.log.Info() }
+func (l *captureLogger) Trace() *zerolog.Event        { return l.log.Trace() }
+func (l *captureLogger) Debug() *zerolog.Event        { return l.log.Debug() }
+func (l *captureLogger) With() zerolog.Context        { return l.log.With() }
+func (l *captureLogger) SetLogLevel(string)           {}
 
 func TestMissingOptionalConfigKeysUseDefaults(t *testing.T) {
 	configFile := writeTestConfig(t, `
@@ -351,6 +391,67 @@ clients:
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for completed config reload")
 	}
+	require.Equal(t, "after", cfg.Snapshot().Clients["default"].Import.Category)
+}
+
+func TestDynamicReloadDebouncesTruncateFirstWrites(t *testing.T) {
+	previousLogLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(previousLogLevel)
+	})
+
+	cfg, configFile := newTestAppConfig(t, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: before
+logLevel: DEBUG
+`)
+	output := &synchronizedBuffer{}
+	reloads, err := cfg.DynamicReload(newCaptureLogger(output))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NotNil(t, cfg.watcher)
+		require.NoError(t, cfg.watcher.Unwatch())
+	})
+
+	writer, err := os.OpenFile(configFile, os.O_WRONLY|os.O_TRUNC, 0)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	time.Sleep(configReloadDebounceDelay / 4)
+
+	writer, err = os.OpenFile(configFile, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	_, err = writer.WriteString(`
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: after
+logLevel: DEBUG
+`)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	time.Sleep(configReloadDebounceDelay / 4)
+
+	writer, err = os.OpenFile(configFile, os.O_WRONLY|os.O_APPEND, 0)
+	require.NoError(t, err)
+	_, err = writer.WriteString("\n")
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for config reload")
+	}
+	time.Sleep(2 * configReloadDebounceDelay)
+
+	logs := output.String()
+	require.NotContains(t, logs, "config reload rejected", logs)
+	require.Equal(t, 1, bytes.Count([]byte(logs), []byte("config file reloaded")), logs)
 	require.Equal(t, "after", cfg.Snapshot().Clients["default"].Import.Category)
 }
 


### PR DESCRIPTION
## Problem

A single truncate-first config save can emit several filesystem events. The watcher slept for 10 ms inside every callback, so it could observe an empty intermediate file and then reload the completed config more than once. Production logs and an isolated Linux reproduction showed one rejection followed by duplicate successful reloads.

## Fix

Use a 100 ms trailing-edge debounce. An atomic generation invalidates stale callbacks, and a mutex serializes actual reloads. Empty or invalid configs still keep the previous validated snapshot active. The config reload specification now requires one reload attempt per save event burst.

## Tests

- Added a regression test that performs the same truncate, write, and append sequence, then asserts no rejection, one reload, and the updated snapshot.
- Ran the regression 20 times on macOS and 20 times in Linux.
- Started the service and performed two live multi-write config saves. Each produced one reload, activated the new authentication setting, and kept the liveness endpoint healthy.
