### PR TITLE
fix(config): keep reload watcher alive across replacements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/autobrr/go-qbittorrent v1.17.0
 	github.com/autobrr/go-torrent v1.1.0
 	github.com/dlclark/regexp2 v1.12.0
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-contrib/requestid v1.0.6
 	github.com/gin-gonic/gin v1.12.0
@@ -46,7 +47,6 @@ require (
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nuxencs/seasonpackarr/internal/logger"
 	"github.com/nuxencs/seasonpackarr/pkg/errors"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/structs"
@@ -406,7 +407,7 @@ type AppConfig struct {
 	configFile        string
 	version           string
 	disableConfigFile bool
-	watcher           *file.File
+	watcher           *fsnotify.Watcher
 }
 
 func New(configPath string, version string) *AppConfig {
@@ -829,13 +830,70 @@ func (c *AppConfig) reload() (*domain.Config, error) {
 
 const configReloadDebounceDelay = 100 * time.Millisecond
 
+func (c *AppConfig) watchConfigFile(log logger.Logger, onChange func()) error {
+	watchedPath := filepath.Clean(c.configFile)
+	realPath, err := filepath.EvalSymlinks(watchedPath)
+	if err != nil {
+		return err
+	}
+	realPath = filepath.Clean(realPath)
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	if err := watcher.Add(filepath.Dir(watchedPath)); err != nil {
+		_ = watcher.Close()
+		return err
+	}
+	c.watcher = watcher
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+
+				eventPath := filepath.Clean(event.Name)
+				currentRealPath, err := filepath.EvalSymlinks(watchedPath)
+				if err != nil {
+					if os.IsNotExist(err) {
+						onWatchedFile := eventPath == watchedPath || eventPath == realPath
+						if onWatchedFile && event.Has(fsnotify.Remove|fsnotify.Rename) {
+							onChange()
+						}
+					} else {
+						log.Error().Err(err).Msg("error resolving watched config file")
+					}
+					continue
+				}
+				currentRealPath = filepath.Clean(currentRealPath)
+
+				onWatchedFile := eventPath == watchedPath || eventPath == realPath
+				targetChanged := currentRealPath != realPath
+				if targetChanged || (onWatchedFile && event.Has(fsnotify.Create|fsnotify.Write)) {
+					realPath = currentRealPath
+					onChange()
+				}
+			case watchErr, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				log.Error().Err(watchErr).Msg("error watching config file")
+			}
+		}
+	}()
+
+	return nil
+}
+
 func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 	if c.disableConfigFile {
 		return nil, nil
 	}
 
-	// use koanf's built-in file watcher
-	f := file.Provider(c.configFile)
 	reloaded := make(chan struct{}, 1)
 	var (
 		reloadGeneration atomic.Uint64
@@ -874,14 +932,7 @@ func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 		})
 	}
 
-	// watch the config file for changes
-	err := f.Watch(func(_ any, watchErr error) {
-		if watchErr != nil {
-			reloadGeneration.Add(1)
-			log.Error().Err(watchErr).Msg("error watching config file")
-			return
-		}
-
+	err := c.watchConfigFile(log, func() {
 		// Editors and bind mounts can emit several write events for one save.
 		// Reload after the event burst becomes quiet so truncate-first writes do
 		// not produce a transient rejection or duplicate successful reloads.
@@ -890,7 +941,5 @@ func (c *AppConfig) DynamicReload(log logger.Logger) (<-chan struct{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("watching config file %s: %w", c.configFile, err)
 	}
-	c.watcher = f
-
 	return reloaded, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -297,7 +297,7 @@ clients:
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NotNil(t, cfg.watcher)
-		require.NoError(t, cfg.watcher.Unwatch())
+		require.NoError(t, cfg.watcher.Close())
 	})
 
 	readerResult := make(chan error, 1)
@@ -356,7 +356,7 @@ clients:
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NotNil(t, cfg.watcher)
-		require.NoError(t, cfg.watcher.Unwatch())
+		require.NoError(t, cfg.watcher.Close())
 	})
 
 	configWriter, err := os.OpenFile(configFile, os.O_WRONLY|os.O_TRUNC, 0)
@@ -414,7 +414,7 @@ logLevel: DEBUG
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NotNil(t, cfg.watcher)
-		require.NoError(t, cfg.watcher.Unwatch())
+		require.NoError(t, cfg.watcher.Close())
 	})
 
 	writer, err := os.OpenFile(configFile, os.O_WRONLY|os.O_TRUNC, 0)
@@ -452,6 +452,123 @@ logLevel: DEBUG
 	logs := output.String()
 	require.NotContains(t, logs, "config reload rejected", logs)
 	require.Equal(t, 1, bytes.Count([]byte(logs), []byte("config file reloaded")), logs)
+	require.Equal(t, "after", cfg.Snapshot().Clients["default"].Import.Category)
+}
+
+func TestDynamicReloadSurvivesRenameAndRecreateSave(t *testing.T) {
+	previousLogLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(previousLogLevel)
+	})
+
+	cfg, configFile := newTestAppConfig(t, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: before
+`)
+	output := &synchronizedBuffer{}
+	reloads, err := cfg.DynamicReload(newCaptureLogger(output))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NotNil(t, cfg.watcher)
+		require.NoError(t, cfg.watcher.Close())
+	})
+
+	backupFile := configFile + ".backup"
+	require.NoError(t, os.Rename(configFile, backupFile))
+	time.Sleep(2 * configReloadDebounceDelay)
+	require.Contains(t, output.String(), "config reload rejected; keeping previous config")
+
+	writeConfigFile(t, configFile, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: after-first-save
+`)
+
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reload after rename-and-recreate save")
+	}
+	require.Equal(t, "after-first-save", cfg.Snapshot().Clients["default"].Import.Category)
+
+	writeConfigFile(t, configFile, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: after-second-save
+`)
+
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reload after the next save")
+	}
+	require.Equal(t, "after-second-save", cfg.Snapshot().Clients["default"].Import.Category)
+	require.NotContains(t, output.String(), "error watching config file")
+}
+
+func TestDynamicReloadFollowsReplacedConfigSymlink(t *testing.T) {
+	previousLogLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(previousLogLevel)
+	})
+
+	configDir := t.TempDir()
+	firstTarget := filepath.Join(configDir, "config-first.yaml")
+	secondTarget := filepath.Join(configDir, "config-second.yaml")
+	configFile := filepath.Join(configDir, "config.yaml")
+	writeConfigFile(t, firstTarget, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: before
+`)
+	writeConfigFile(t, secondTarget, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: after
+`)
+	if err := os.Symlink(firstTarget, configFile); err != nil {
+		t.Skipf("config symlinks are unavailable: %v", err)
+	}
+	nextSymlink := configFile + ".next"
+	require.NoError(t, os.Symlink(secondTarget, nextSymlink))
+
+	cfg := &AppConfig{configFile: configFile, version: "test"}
+	snapshot, err := cfg.loadSnapshot()
+	require.NoError(t, err)
+	cfg.current.Store(snapshot)
+	reloads, err := cfg.DynamicReload(logger.New(snapshot))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NotNil(t, cfg.watcher)
+		require.NoError(t, cfg.watcher.Close())
+	})
+
+	time.Sleep(configReloadDebounceDelay)
+	require.NoError(t, os.Rename(nextSymlink, configFile))
+	writeConfigFile(t, secondTarget, `
+clients:
+  default:
+    type: qbittorrent
+    import:
+      category: after
+`)
+
+	select {
+	case <-reloads:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for reload after config symlink replacement")
+	}
 	require.Equal(t, "after", cfg.Snapshot().Clients["default"].Import.Category)
 }
 


### PR DESCRIPTION
## Problem

Vim atomic saves temporarily remove `config.yaml`. The koanf file provider resolves the path during that gap, reports an `lstat` error, and permanently stops its watch loop. Later valid saves do not reload the configuration.

The failure was reproduced against the running Linux service with a real Vim save.

## Fix

Watch the configuration parent directory directly with fsnotify while keeping koanf for parsing and loading. File removal now rejects that reload and keeps the previous snapshot active. Recreation, later writes, atomic replacements, and symlink target changes continue to reload normally.

The existing debounce, complete-snapshot validation, environment overrides, and log-level updates remain unchanged.

## Tests

- Added regression coverage for removal, recreation, and a subsequent save.
- Added coverage for replaced configuration symlinks.
- Repeated the config package 20 times and ran it with the race detector.
- Ran 10 real Vim atomic saves against the Linux Docker service. All 10 reloaded with no watcher or reload errors.
