### PR TITLE
perf(torrentclient): batch candidate file reads

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,7 @@
 
 - `/api/candidate` reads torrent summaries only. It does not need torrent bytes or file-detail calls.
 - `/api/pack` parses the announced torrent, maps reusable source files to distinct valid torrent targets, and applies smart mode to exact torrent coverage.
+- Exact planning requests candidate file details once. Transmission and Deluge v2 batch hashes in one client call. Deluge v1 uses one session-state preflight and one bulk status call. qBittorrent uses a bounded four-worker adapter pool.
 - Client inventory is cached for 30 seconds, so the ordered candidate and pack checks normally share one client scan.
 - Accepted import plans are cached for 2 minutes. `/api/parse` normally performs no second inventory or file-detail reads.
 - Cache entries validate client configuration, matching settings, release name, and torrent identity. `/api/parse` rebuilds safely on a cache miss.

--- a/docs/references/torrent-client-file-read-performance.md
+++ b/docs/references/torrent-client-file-read-performance.md
@@ -1,0 +1,195 @@
+# Torrent Client File Read Performance
+
+Research date: 2026-08-11
+
+## Decision
+
+Add one bulk read contract at the `torrentclient` boundary. Suggested shape:
+
+```go
+type FileResult struct {
+	Hash  string
+	Files []File
+	Err   error
+}
+
+GetFiles(hashes []string) []FileResult
+```
+
+Return exactly one result for each input, in input order. A missing torrent is a
+per-hash error. A qBittorrent request error applies only to its hash. A
+Transmission or Deluge whole-call error is copied into every requested result.
+Successful results stay usable when another result fails. This preserves the
+current planner behavior and candidate order even when a client returns a map
+or a different order. Match returned hashes case-insensitively, but keep the
+input spelling in `FileResult.Hash`.
+
+Recommended implementations:
+
+| Client | This PR | Later option |
+| --- | --- | --- |
+| qBittorrent | Run the existing single-hash request with a bounded worker pool. Start with 4 workers. | For qBittorrent 5.2 or later, add wrapper support for one `torrents/info` request with `includeFiles=true`. |
+| Transmission | Send one `TorrentGetHashes` request for all candidate hashes. Request only `hashString` and `files`. | Chunk only after measured response-size or timeout failures. |
+| Deluge v2 | Send one serialized `TorrentsStatus` request with all candidate hashes. | Add a `go-deluge` API that accepts status keys, then request only `hash` and `files`. |
+| Deluge v1 | Read `SessionState`, then send one serialized `TorrentsStatus` request with the known, unique candidate hashes. | Add an explicit-key wrapper API that handles unknown IDs without decoding empty status dictionaries. |
+
+Ship this client-read change before parse-once episode indexing. The changes
+meet at the plan builder, but stay separate behind the torrent-client and
+release matcher seams.
+
+## qBittorrent
+
+The pinned `github.com/autobrr/go-qbittorrent` v1.17.0 implementation exposes
+only a single-hash file read. `GetFilesInformationCtx` sends
+`GET torrents/files?hash=<hash>`, returns 404 for a missing torrent, and decodes
+one file list ([source](https://github.com/autobrr/go-qbittorrent/blob/ba1163d4a82164d71adb57123049f809f3b71855/methods.go#L1431-L1460)). Its
+filter options support many hashes for `torrents/info`, but do not expose
+`includeFiles`, and the pinned `Torrent` model has no `files` member
+([options](https://github.com/autobrr/go-qbittorrent/blob/ba1163d4a82164d71adb57123049f809f3b71855/domain.go#L486-L496),
+[model](https://github.com/autobrr/go-qbittorrent/blob/ba1163d4a82164d71adb57123049f809f3b71855/domain.go#L57-L117)).
+
+Bounded concurrency is the compatible path. The wrapper uses one shared
+`http.Client`, has no request-wide mutex, and configures connection reuse with
+10 idle connections per host
+([source](https://github.com/autobrr/go-qbittorrent/blob/ba1163d4a82164d71adb57123049f809f3b71855/qbittorrent.go#L20-L31),
+[transport](https://github.com/autobrr/go-qbittorrent/blob/ba1163d4a82164d71adb57123049f809f3b71855/qbittorrent.go#L92-L115)).
+The Go `http.Client` contract supports concurrent use
+([documentation](https://pkg.go.dev/net/http#Client)). Keep the pool below the
+wrapper's per-host connection setting. Four workers limit qBittorrent CPU,
+response memory, and retry bursts while removing serial round trips.
+
+qBittorrent 5.2 adds the better server-side batch option. Web API 2.11.8 added
+`includeFiles` to `torrents/info`
+([changelog](https://github.com/qbittorrent/qBittorrent/blob/b2270f7f6fec1b10117564f642b961621ae0058a/WebAPI_Changelog.md#L90-L100)).
+The endpoint accepts pipe-separated hashes, iterates the session's torrent
+list, and includes files only when metadata exists
+([implementation](https://github.com/qbittorrent/qBittorrent/blob/b2270f7f6fec1b10117564f642b961621ae0058a/src/webui/api/torrentscontroller.cpp#L586-L640)).
+Consequences:
+
+- Response order is session order, not request order.
+- Unknown hashes are omitted.
+- A magnet without metadata can be returned without a `files` field.
+- The response includes the full torrent summary plus files. It costs more
+  payload per torrent than `torrents/files`.
+- The GET query grows by about 41 bytes per v1 hash, before URL encoding.
+  Chunking is required if large candidate sets meet proxy URI limits.
+
+Do not add a private raw HTTP implementation in seasonpackarr. The pinned
+wrapper owns authentication, cookies, retries, and endpoint construction. Add
+or adopt wrapper support first, then gate this path on Web API 2.11.8. Keep the
+worker-pool fallback for older qBittorrent releases.
+
+Partial-error rule for this PR: do not cancel other workers after one failure.
+Write each success or error into its preassigned result index. The planner logs
+and skips failed results, then consumes successes in original candidate order.
+
+## Transmission
+
+The pinned `github.com/hekmon/transmissionrpc/v3` v3.0.0 already implements the
+required batch. `TorrentGetHashes` passes the complete hash slice as the RPC
+`ids` array in one `torrent-get` call
+([source](https://github.com/hekmon/transmissionrpc/blob/a9d6476918d29167ccda86b94ba728616e5af53d/torrent_accessors.go#L51-L57),
+[encoding](https://github.com/hekmon/transmissionrpc/blob/a9d6476918d29167ccda86b94ba728616e5af53d/torrent_accessors.go#L92-L116)).
+The model supports both `hashString` and `files`
+([source](https://github.com/hekmon/transmissionrpc/blob/a9d6476918d29167ccda86b94ba728616e5af53d/torrent_accessors.go#L141-L149)).
+
+Use:
+
+```go
+TorrentGetHashes(ctx, []string{"hashString", "files"}, hashes)
+```
+
+Transmission 4.0.3 accepts a mixed list of IDs and hashes. For a list, it walks
+the request in order and appends only torrents that exist
+([RPC contract](https://github.com/transmission/transmission/blob/6b0e49bbb296f1c84785275b8a8f18b4210180af/docs/rpc-spec.md#L123-L130),
+[selection code](https://github.com/transmission/transmission/blob/6b0e49bbb296f1c84785275b8a8f18b4210180af/libtransmission/rpcimpl.cc#L88-L119)).
+The response is built in that selected order
+([source](https://github.com/transmission/transmission/blob/6b0e49bbb296f1c84785275b8a8f18b4210180af/libtransmission/rpcimpl.cc#L919-L957)).
+Build an internal response map by a lower-case `hashString`, then emit one
+result for each input hash. This detects omitted hashes and avoids relying on
+server ordering.
+
+One RPC has one success or failure result. It has no per-torrent error field.
+Unknown hashes are omissions, not request errors. Treat every requested hash
+that is absent from the response as a missing-torrent error. For a transport,
+authentication, decode, or RPC result error, return that error in every input
+result.
+
+Payload is close to the aggregate serial payload, plus one `hashString` per
+torrent. It removes repeated HTTP headers, JSON envelopes, and round trips.
+The library decodes the complete response into a torrent slice. Do not add
+concurrency. Start with one batch and the existing 60-second context. Add
+chunks only if live measurements show large responses or timeouts.
+
+The library itself can support concurrent HTTP calls. It uses a pooled HTTP
+client and locks its random tag source and session ID
+([source](https://github.com/hekmon/transmissionrpc/blob/a9d6476918d29167ccda86b94ba728616e5af53d/controller.go#L28-L68),
+[locks](https://github.com/hekmon/transmissionrpc/blob/a9d6476918d29167ccda86b94ba728616e5af53d/controller.go#L71-L109)).
+That capability is not useful here because the protocol already provides the
+single-request batch.
+
+## Deluge
+
+The pinned `github.com/autobrr/go-deluge` v1.4.0 already exposes a semantic
+batch. `TorrentsStatus` sends one `core.get_torrents_status` call with an `id`
+filter containing all requested hashes
+([source](https://github.com/autobrr/go-deluge/blob/245951c9058483f9637d5e1a0f5ac11941c89828/torrent_status.go#L162-L180)).
+It returns a map keyed by hash
+([source](https://github.com/autobrr/go-deluge/blob/245951c9058483f9637d5e1a0f5ac11941c89828/torrent_status.go#L185-L212)).
+
+The main limitation is payload. The method always requests the wrapper's full
+status list. That list includes `files`, file progress, priorities, peers, and
+many summary fields
+([source](https://github.com/autobrr/go-deluge/blob/245951c9058483f9637d5e1a0f5ac11941c89828/torrent_status.go#L85-L129)).
+For this PR, one compressed full-status response is still preferable to one
+full-status response per candidate. The next improvement is a wrapper method
+that accepts explicit status keys. Deluge core already accepts a `keys` list
+and applies it to all selected torrents
+([Deluge 2.1.1](https://github.com/deluge-torrent/deluge/blob/0b5f45b486e8e974ba8a0b1d6e8edcd124fca62a/deluge/core/core.py#L764-L779),
+[Deluge 1.3.15](https://github.com/deluge-torrent/deluge/blob/a6e8ac8725c2be28679e26b7c6674aad339338b1/deluge/core/core.py#L456-L468)).
+The ideal request uses only `hash` and `files`.
+
+Do not call the native Deluge client concurrently. The pinned wrapper increments
+an unprotected serial, writes to one connection, immediately reads one response,
+and rejects a response with a different serial
+([request path](https://github.com/autobrr/go-deluge/blob/245951c9058483f9637d5e1a0f5ac11941c89828/delugeclient.go#L299-L315),
+[read and validation](https://github.com/autobrr/go-deluge/blob/245951c9058483f9637d5e1a0f5ac11941c89828/delugeclient.go#L331-L449)).
+Hold the existing `delugeClient.mu` for the complete bulk call.
+
+Missing-hash behavior differs by daemon generation:
+
+- Deluge 2.1.1 deletes unknown IDs before it returns the status dictionary
+  ([source](https://github.com/deluge-torrent/deluge/blob/0b5f45b486e8e974ba8a0b1d6e8edcd124fca62a/deluge/core/torrentmanager.py#L1659-L1676)).
+- Deluge 1.3.15 keeps the requested key and returns an empty status dictionary
+  for a missing torrent
+  ([source](https://github.com/deluge-torrent/deluge/blob/a6e8ac8725c2be28679e26b7c6674aad339338b1/deluge/core/core.py#L442-L468)).
+
+The pinned wrapper tries to decode every v1 dictionary into a complete
+`TorrentStatus`. An empty dictionary fails at the first required field before
+the caller can inspect map presence. The v1 adapter therefore reads the small
+session hash list first, removes unknown and duplicate IDs, then sends one bulk
+status request for known hashes. Deluge v2 uses the direct bulk status request.
+Both paths require a non-empty `TorrentStatus.Hash`, match hashes
+case-insensitively, and emit results in input order. For a whole-call error,
+return that error in every input result.
+
+For Deluge v2, the wrapper reads the complete compressed frame into memory
+before rencode decoding
+([source](https://github.com/autobrr/go-deluge/blob/245951c9058483f9637d5e1a0f5ac11941c89828/delugeclient.go#L367-L407)).
+This makes the explicit-key wrapper improvement valuable if candidate sets or
+file lists become large. Until then, one serialized call is the simplest
+end-to-end improvement.
+
+## Verification Targets
+
+- Shared contract test: successful entries remain usable when one hash fails.
+- Shared contract test: output processing follows candidate order.
+- qBittorrent: worker limit, mixed success and 404, no worker leak.
+- Transmission: one API call, request fields are exactly `hashString` and
+  `files`, missing hash omission, response order does not affect planning.
+- Deluge v2: one API call under the mutex, unordered map, missing-hash omission,
+  full-call error.
+- Deluge v1: one session-state call plus one bulk status call under the mutex,
+  unknown and duplicate filtering, full-call error.
+- Plan builder: an error for one candidate does not discard successful
+  candidates, matching stops after all eligible torrent targets are filled.

--- a/internal/http/processor_plan.go
+++ b/internal/http/processor_plan.go
@@ -6,10 +6,12 @@ package http
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/internal/release"
+	"github.com/nuxencs/seasonpackarr/internal/torrentclient"
 	"github.com/nuxencs/seasonpackarr/internal/torrents"
 	"github.com/nuxencs/seasonpackarr/pkg/errors"
 
@@ -121,9 +123,25 @@ func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client,
 		return importPlan{}, domain.StatusParseTorrentInfoError, fmt.Errorf("%s: %w", domain.StatusParseTorrentInfoError, err)
 	}
 
+	fileResults := p.getFiles(candidates)
 	linksByTarget := make(map[string]plannedLink)
-	for _, candidate := range candidates {
-		fileName, size, err := p.getFiles(candidate.torrent.Hash)
+	for index, candidate := range candidates {
+		if index >= len(fileResults) {
+			p.log.Error().Msgf("torrent client omitted file result for %s", candidate.torrent.Name)
+			continue
+		}
+
+		result := fileResults[index]
+		if !strings.EqualFold(result.Hash, candidate.torrent.Hash) {
+			p.log.Error().Msgf("torrent client returned out-of-order file result for %s", candidate.torrent.Name)
+			continue
+		}
+		if result.Err != nil {
+			p.log.Error().Err(result.Err).Msgf("error getting file info: %s", candidate.torrent.Name)
+			continue
+		}
+
+		fileName, size, err := episodeFileFromFiles(result.Files)
 		if err != nil {
 			p.log.Error().Err(err).Msgf("error getting file info: %s", candidate.torrent.Name)
 			continue
@@ -162,12 +180,15 @@ func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client,
 	}, domain.StatusSuccessfulMatch, nil
 }
 
-func (p *processor) getFiles(hash string) (string, int64, error) {
-	torrentFiles, err := p.req.Client.GetFiles(hash)
-	if err != nil {
-		return "", 0, err
+func (p *processor) getFiles(candidates []entry) []torrentclient.FileResult {
+	hashes := make([]string, len(candidates))
+	for index, candidate := range candidates {
+		hashes[index] = candidate.torrent.Hash
 	}
+	return p.req.Client.GetFiles(hashes)
+}
 
+func episodeFileFromFiles(torrentFiles []torrentclient.File) (string, int64, error) {
 	var fileName string
 	var size int64
 	for _, f := range torrentFiles {

--- a/internal/http/processor_test.go
+++ b/internal/http/processor_test.go
@@ -30,14 +30,17 @@ import (
 // mockTorrentClient is a configurable in-memory torrentclient.TorrentClient for
 // exercising the processor without a live torrent client.
 type mockTorrentClient struct {
-	torrents     []torrentclient.Torrent
-	torrentsErr  error
-	torrentCalls int
-	files        []torrentclient.File            // returned for any hash when filesByHash is nil
-	filesByHash  map[string][]torrentclient.File // per-hash file lists
-	filesErr     error
-	gotHash      string
-	fileCalls    int
+	torrents       []torrentclient.Torrent
+	torrentsErr    error
+	torrentCalls   int
+	files          []torrentclient.File            // returned for any hash when filesByHash is nil
+	filesByHash    map[string][]torrentclient.File // per-hash file lists
+	filesErr       error
+	fileErrByHash  map[string]error
+	gotHash        string
+	gotHashes      []string
+	fileCalls      int
+	fileBatchCalls int
 
 	importRoot    string
 	importRootErr error
@@ -63,16 +66,32 @@ func (m *mockTorrentClient) GetTorrents() ([]torrentclient.Torrent, error) {
 	return m.torrents, m.torrentsErr
 }
 
-func (m *mockTorrentClient) GetFiles(hash string) ([]torrentclient.File, error) {
-	m.fileCalls++
-	m.gotHash = hash
-	if m.filesErr != nil {
-		return nil, m.filesErr
+func (m *mockTorrentClient) GetFiles(hashes []string) []torrentclient.FileResult {
+	m.fileBatchCalls++
+	m.fileCalls += len(hashes)
+	m.gotHashes = append([]string(nil), hashes...)
+	if len(hashes) > 0 {
+		m.gotHash = hashes[0]
 	}
-	if m.filesByHash != nil {
-		return m.filesByHash[hash], nil
+
+	results := make([]torrentclient.FileResult, len(hashes))
+	for index, hash := range hashes {
+		results[index].Hash = hash
+		if m.filesErr != nil {
+			results[index].Err = m.filesErr
+			continue
+		}
+		if err := m.fileErrByHash[hash]; err != nil {
+			results[index].Err = err
+			continue
+		}
+		if m.filesByHash != nil {
+			results[index].Files = m.filesByHash[hash]
+			continue
+		}
+		results[index].Files = m.files
 	}
-	return m.files, nil
+	return results
 }
 
 func TestCandidateSeasonPackUsesTorrentSummariesOnly(t *testing.T) {
@@ -197,6 +216,7 @@ func TestProcessSeasonPackUsesTorrentEpisodeCoverage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, domain.StatusSuccessfulMatch, statusCode)
 	require.False(t, mock.importCalled, "pack evaluation must remain side-effect free")
+	require.Equal(t, 1, mock.fileBatchCalls, "one plan must use one bulk file read")
 }
 
 func TestProcessSeasonPackRejectsCoverageBelowTorrentThreshold(t *testing.T) {
@@ -387,9 +407,13 @@ func TestTorrentClientPathContract(t *testing.T) {
 		t.Fatalf("len(torrents) = %d, want 1", len(ts))
 	}
 
-	fileName, size, err := p.getFiles(ts[0].Hash)
+	results := p.getFiles([]entry{{torrent: ts[0]}})
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("getFiles: %+v", results)
+	}
+	fileName, size, err := episodeFileFromFiles(results[0].Files)
 	if err != nil {
-		t.Fatalf("getFiles: %v", err)
+		t.Fatalf("episodeFileFromFiles: %v", err)
 	}
 	if mock.gotHash != "abc123" {
 		t.Errorf("GetFiles called with hash %q, want abc123", mock.gotHash)
@@ -413,9 +437,7 @@ func TestGetFilesSelectsFirstValidEpisode(t *testing.T) {
 			{Name: "Some.Show.S01/Some.Show.S01E02.mkv", Size: 1_100_000},
 		},
 	}
-	p := newTestProcessor(mock)
-
-	fileName, size, err := p.getFiles("h")
+	fileName, size, err := episodeFileFromFiles(mock.files)
 	if err != nil {
 		t.Fatalf("getFiles: %v", err)
 	}
@@ -434,9 +456,7 @@ func TestGetFilesErrorsWhenNoValidEpisode(t *testing.T) {
 			{Name: "Some.Show.S01/readme.txt", Size: 10},
 		},
 	}
-	p := newTestProcessor(mock)
-
-	if _, _, err := p.getFiles("h"); err == nil {
+	if _, _, err := episodeFileFromFiles(mock.files); err == nil {
 		t.Fatal("expected error when no valid episode file is present, got nil")
 	}
 }
@@ -445,8 +465,9 @@ func TestGetFilesPropagatesClientError(t *testing.T) {
 	errBoom := errors.New("boom")
 	p := newTestProcessor(&mockTorrentClient{filesErr: errBoom})
 
-	if _, _, err := p.getFiles("h"); !errors.Is(err, errBoom) {
-		t.Fatalf("getFiles error = %v, want it to wrap errBoom", err)
+	results := p.getFiles([]entry{{torrent: torrentclient.Torrent{Hash: "h"}}})
+	if len(results) != 1 || !errors.Is(results[0].Err, errBoom) {
+		t.Fatalf("getFiles result = %+v, want it to wrap errBoom", results)
 	}
 }
 

--- a/internal/torrentclient/client.go
+++ b/internal/torrentclient/client.go
@@ -40,6 +40,15 @@ type File struct {
 	Size int64
 }
 
+// FileResult is one ordered response to a hash supplied to GetFiles. Err is
+// scoped to that hash, so callers can keep successful results from a partial
+// read.
+type FileResult struct {
+	Hash  string
+	Files []File
+	Err   error
+}
+
 // ImportRequest carries a parsed season pack to be (re-)imported into the
 // client on /api/parse. The processor has already hardlinked the matched local
 // episodes into SavePath before Import is called.
@@ -145,9 +154,19 @@ func ImportStatusCode(err error) domain.StatusCode {
 // Import failures are returned as *ImportError.
 type TorrentClient interface {
 	GetTorrents() ([]Torrent, error)
-	GetFiles(hash string) ([]File, error)
+	// GetFiles returns exactly one result per input hash in input order. Each
+	// adapter owns its safe batching or concurrency strategy.
+	GetFiles(hashes []string) []FileResult
 	ImportDestination() (ImportDestination, error)
 	Import(req ImportRequest) error
+}
+
+func fileResultsWithError(hashes []string, err error) []FileResult {
+	results := make([]FileResult, len(hashes))
+	for index, hash := range hashes {
+		results[index] = FileResult{Hash: hash, Err: err}
+	}
+	return results
 }
 
 // pollUntil invokes cond every interval until it reports done, cond returns an

--- a/internal/torrentclient/deluge.go
+++ b/internal/torrentclient/deluge.go
@@ -28,6 +28,7 @@ const (
 // call is serialized by delugeClient.mu.
 type delugeAPI interface {
 	Connect(ctx context.Context) error
+	SessionState(ctx context.Context) ([]string, error)
 	TorrentsStatus(ctx context.Context, state deluge.TorrentState, ids []string) (map[string]*deluge.TorrentStatus, error)
 	TorrentStatus(ctx context.Context, id string) (*deluge.TorrentStatus, error)
 	AddTorrentFile(ctx context.Context, fileName, fileContentBase64 string, options *deluge.Options) (string, error)
@@ -47,6 +48,7 @@ type delugeClient struct {
 	policy domain.ImportPolicy
 	mu     sync.Mutex
 	label  delugeLabelPluginFactory
+	v1     bool
 
 	// timeouts are fields so tests can shrink them to milliseconds.
 	checkTimeout time.Duration
@@ -65,6 +67,9 @@ func newDelugeClient(client *domain.Client) (*delugeClient, error) {
 	case "deluge-v1":
 		raw := deluge.NewV1(settings)
 		c = raw
+		// Deluge v1 returns an empty status dictionary for an unknown ID.
+		// go-deluge cannot decode that dictionary, so GetFiles must filter
+		// unknown IDs through SessionState before its bulk status request.
 		label = func(ctx context.Context) (delugeLabelAPI, error) {
 			return raw.LabelPlugin(ctx)
 		}
@@ -88,6 +93,7 @@ func newDelugeClient(client *domain.Client) (*delugeClient, error) {
 		c:            c,
 		policy:       client.Import,
 		label:        label,
+		v1:           client.Type == "deluge-v1",
 		checkTimeout: 10 * time.Minute,
 		pollInterval: 500 * time.Millisecond,
 	}, nil
@@ -164,29 +170,81 @@ func (d *delugeClient) GetTorrents() ([]Torrent, error) {
 	return torrents, nil
 }
 
-func (d *delugeClient) GetFiles(hash string) ([]File, error) {
+func (d *delugeClient) GetFiles(hashes []string) []FileResult {
+	if len(hashes) == 0 {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), delugeTimeout)
 	defer cancel()
 
-	d.mu.Lock()
-	status, err := d.c.TorrentStatus(ctx, hash)
-	d.mu.Unlock()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get files from deluge")
-	}
-	if status == nil {
-		return nil, fmt.Errorf("deluge: torrent not found: %s", hash)
-	}
+	requestedHashes := uniqueFoldedHashes(hashes)
 
-	files := make([]File, 0, len(status.Files))
-	for _, file := range status.Files {
-		files = append(files, File{
-			Name: file.Path,
-			Size: file.Size,
+	d.mu.Lock()
+	if d.v1 {
+		sessionHashes, err := d.c.SessionState(ctx)
+		if err != nil {
+			d.mu.Unlock()
+			return fileResultsWithError(hashes, errors.Wrap(err, "failed to list deluge torrents"))
+		}
+		knownHashes := make(map[string]struct{}, len(sessionHashes))
+		for _, hash := range sessionHashes {
+			knownHashes[strings.ToLower(hash)] = struct{}{}
+		}
+		requestedHashes = slices.DeleteFunc(requestedHashes, func(hash string) bool {
+			_, ok := knownHashes[strings.ToLower(hash)]
+			return !ok
 		})
 	}
 
-	return files, nil
+	var statuses map[string]*deluge.TorrentStatus
+	var err error
+	if len(requestedHashes) != 0 {
+		statuses, err = d.c.TorrentsStatus(ctx, deluge.StateUnspecified, requestedHashes)
+	}
+	d.mu.Unlock()
+	if err != nil {
+		return fileResultsWithError(hashes, errors.Wrap(err, "failed to get files from deluge"))
+	}
+
+	statusByHash := make(map[string]*deluge.TorrentStatus, len(statuses))
+	for _, status := range statuses {
+		if status == nil || strings.TrimSpace(status.Hash) == "" {
+			continue
+		}
+		statusByHash[strings.ToLower(status.Hash)] = status
+	}
+
+	results := make([]FileResult, len(hashes))
+	for index, hash := range hashes {
+		results[index].Hash = hash
+		status, ok := statusByHash[strings.ToLower(hash)]
+		if !ok {
+			results[index].Err = fmt.Errorf("deluge: torrent not found: %s", hash)
+			continue
+		}
+
+		files := make([]File, 0, len(status.Files))
+		for _, file := range status.Files {
+			files = append(files, File{Name: file.Path, Size: file.Size})
+		}
+		results[index].Files = files
+	}
+	return results
+}
+
+func uniqueFoldedHashes(hashes []string) []string {
+	seen := make(map[string]struct{}, len(hashes))
+	unique := make([]string, 0, len(hashes))
+	for _, hash := range hashes {
+		key := strings.ToLower(hash)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, hash)
+	}
+	return unique
 }
 
 // ImportDestination uses an explicit path because go-deluge does not expose

--- a/internal/torrentclient/deluge_live_test.go
+++ b/internal/torrentclient/deluge_live_test.go
@@ -114,13 +114,15 @@ func TestDelugeImportLive(t *testing.T) {
 		if len(torrents) != 1 || torrents[0].SavePath != filepath.Clean(importDir) {
 			t.Fatalf("unexpected torrents: %+v", torrents)
 		}
-		files, err := c.GetFiles(hashes.Legacy)
-		if err != nil {
-			t.Fatalf("list files: %v", err)
+		results := c.GetFiles([]string{hashes.Legacy})
+		if len(results) != 1 || results[0].Err != nil {
+			t.Fatalf("list files: %+v", results)
 		}
+		files := results[0].Files
 		if len(files) != 3 || !strings.HasPrefix(files[0].Name, packName+"/") {
 			t.Fatalf("unexpected files: %+v", files)
 		}
+		requireFileReadLoad(t, c, hashes.Legacy)
 		requireDelugeLabel(t, c, hashes.Legacy, "seasonpackarr")
 	})
 

--- a/internal/torrentclient/deluge_test.go
+++ b/internal/torrentclient/deluge_test.go
@@ -6,6 +6,7 @@ package torrentclient
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"testing"
 	"time"
 
@@ -15,10 +16,16 @@ import (
 )
 
 type stubDelugeAPI struct {
-	torrents map[string]*deluge.TorrentStatus
-	status   *deluge.TorrentStatus
-	statuses []*deluge.TorrentStatus
-	statusAt int
+	torrents      map[string]*deluge.TorrentStatus
+	torrentsErr   error
+	torrentCalls  int
+	gotTorrentIDs []string
+	sessionHashes []string
+	sessionErr    error
+	sessionCalls  int
+	status        *deluge.TorrentStatus
+	statuses      []*deluge.TorrentStatus
+	statusAt      int
 
 	addedName    string
 	addedContent string
@@ -48,8 +55,15 @@ func (s *stubDelugeLabelAPI) AddLabel(_ context.Context, label string) error {
 
 func (s *stubDelugeAPI) Connect(context.Context) error { return nil }
 
-func (s *stubDelugeAPI) TorrentsStatus(context.Context, deluge.TorrentState, []string) (map[string]*deluge.TorrentStatus, error) {
-	return s.torrents, nil
+func (s *stubDelugeAPI) SessionState(context.Context) ([]string, error) {
+	s.sessionCalls++
+	return s.sessionHashes, s.sessionErr
+}
+
+func (s *stubDelugeAPI) TorrentsStatus(_ context.Context, _ deluge.TorrentState, ids []string) (map[string]*deluge.TorrentStatus, error) {
+	s.torrentCalls++
+	s.gotTorrentIDs = append([]string(nil), ids...)
+	return s.torrents, s.torrentsErr
 }
 
 func (s *stubDelugeAPI) TorrentStatus(context.Context, string) (*deluge.TorrentStatus, error) {
@@ -158,12 +172,16 @@ func TestDelugeGetTorrentsAndFiles(t *testing.T) {
 	stub := &stubDelugeAPI{
 		torrents: map[string]*deluge.TorrentStatus{
 			"bbbb": {Hash: "bbbb", Name: "Show.S01E02", DownloadLocation: "/downloads"},
-			"aaaa": {Name: "Show.S01E01", SavePath: "/legacy-downloads"},
+			"aaaa": {
+				Hash:     "aaaa",
+				Name:     "Show.S01E01",
+				SavePath: "/legacy-downloads",
+				Files: []deluge.File{
+					{Path: "Show.S01/Show.S01E01.mkv", Size: 100},
+					{Path: "Show.S01/Show.S01E02.mkv", Size: 200},
+				},
+			},
 		},
-		status: &deluge.TorrentStatus{Files: []deluge.File{
-			{Path: "Show.S01/Show.S01E01.mkv", Size: 100},
-			{Path: "Show.S01/Show.S01E02.mkv", Size: 200},
-		}},
 	}
 	client := newTestDelugeClient(stub, domain.ImportPolicy{})
 
@@ -174,12 +192,66 @@ func TestDelugeGetTorrentsAndFiles(t *testing.T) {
 		{Hash: "bbbb", Name: "Show.S01E02", SavePath: "/downloads"},
 	}, torrents)
 
-	files, err := client.GetFiles("aaaa")
-	require.NoError(t, err)
+	results := client.GetFiles([]string{"AAAA", "missing"})
+	require.Len(t, results, 2)
+	require.NoError(t, results[0].Err)
+	require.Equal(t, "AAAA", results[0].Hash)
 	require.Equal(t, []File{
 		{Name: "Show.S01/Show.S01E01.mkv", Size: 100},
 		{Name: "Show.S01/Show.S01E02.mkv", Size: 200},
-	}, files)
+	}, results[0].Files)
+	require.Error(t, results[1].Err)
+	require.Equal(t, 2, stub.torrentCalls, "GetTorrents and GetFiles each use one status call")
+	require.Equal(t, []string{"AAAA", "missing"}, stub.gotTorrentIDs)
+}
+
+func TestDelugeGetFilesExpandsWholeCallError(t *testing.T) {
+	t.Parallel()
+
+	errBoom := errors.New("boom")
+	client := newTestDelugeClient(&stubDelugeAPI{torrentsErr: errBoom}, domain.ImportPolicy{})
+	results := client.GetFiles([]string{"one", "two"})
+
+	require.Len(t, results, 2)
+	for index, hash := range []string{"one", "two"} {
+		require.Equal(t, hash, results[index].Hash)
+		require.ErrorIs(t, results[index].Err, errBoom)
+	}
+}
+
+func TestDelugeGetFilesRejectsEmptyV1Status(t *testing.T) {
+	t.Parallel()
+
+	client := newTestDelugeClient(&stubDelugeAPI{
+		torrents: map[string]*deluge.TorrentStatus{"missing": {}},
+	}, domain.ImportPolicy{})
+
+	results := client.GetFiles([]string{"missing"})
+	require.Len(t, results, 1)
+	require.Error(t, results[0].Err)
+}
+
+func TestDelugeV1GetFilesFiltersUnknownAndDuplicateHashes(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubDelugeAPI{
+		sessionHashes: []string{"known"},
+		torrents: map[string]*deluge.TorrentStatus{
+			"known": {Hash: "known", Files: []deluge.File{{Path: "episode.mkv", Size: 100}}},
+		},
+	}
+	client := newTestDelugeClient(stub, domain.ImportPolicy{})
+	client.v1 = true
+
+	results := client.GetFiles([]string{"KNOWN", "known", "missing"})
+
+	require.Len(t, results, 3)
+	require.NoError(t, results[0].Err)
+	require.NoError(t, results[1].Err)
+	require.Error(t, results[2].Err)
+	require.Equal(t, 1, stub.sessionCalls)
+	require.Equal(t, 1, stub.torrentCalls)
+	require.Equal(t, []string{"KNOWN"}, stub.gotTorrentIDs)
 }
 
 func TestDelugeImportDestination(t *testing.T) {

--- a/internal/torrentclient/import_live_test.go
+++ b/internal/torrentclient/import_live_test.go
@@ -145,6 +145,36 @@ func requireTransmissionStarted(t *testing.T, c *transmissionClient, hash string
 	}
 }
 
+// requireFileReadLoad exercises the adapter's multi-hash read shape against a
+// live client. Repeating one known hash isolates read batching and concurrency
+// from torrent setup cost. The missing hash verifies partial-result handling.
+func requireFileReadLoad(t *testing.T, client TorrentClient, hash string) {
+	t.Helper()
+
+	const readCount = 24
+	hashes := make([]string, readCount+1)
+	for index := range readCount {
+		hashes[index] = hash
+	}
+	hashes[readCount] = strings.Repeat("0", 40)
+
+	started := time.Now()
+	results := client.GetFiles(hashes)
+	duration := time.Since(started)
+	if len(results) != len(hashes) {
+		t.Fatalf("GetFiles returned %d results, want %d", len(results), len(hashes))
+	}
+	for index := range readCount {
+		if results[index].Hash != hash || results[index].Err != nil || len(results[index].Files) == 0 {
+			t.Fatalf("GetFiles result %d = %+v, want successful hash %s", index, results[index], hash)
+		}
+	}
+	if results[readCount].Err == nil {
+		t.Fatalf("GetFiles missing-hash result = %+v, want an error", results[readCount])
+	}
+	t.Logf("GetFiles returned %d successful file lists plus one missing result in %s", readCount, duration)
+}
+
 // TestQbitImportLive drives qbitClient.Import against a real qBittorrent.
 //
 //	SEASONPACKARR_TEST_QBIT_HOST=127.0.0.1:8080 \
@@ -175,6 +205,7 @@ func TestQbitImportLive(t *testing.T) {
 		t.Fatalf("qbit Import: %v", err)
 	}
 	requireQbitStarted(t, c, hashes.Legacy)
+	requireFileReadLoad(t, c, hashes.Legacy)
 }
 
 // TestQbitImportDestinationPreferencesLive verifies the category-only path
@@ -283,4 +314,5 @@ func TestTransmissionImportLive(t *testing.T) {
 		t.Fatalf("transmission Import: %v", err)
 	}
 	requireTransmissionStarted(t, c, hashes.Legacy)
+	requireFileReadLoad(t, c, hashes.Legacy)
 }

--- a/internal/torrentclient/qbittorrent.go
+++ b/internal/torrentclient/qbittorrent.go
@@ -6,12 +6,15 @@ package torrentclient
 import (
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/autobrr/go-qbittorrent"
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/pkg/errors"
 )
+
+const qbitFileReadWorkers = 4
 
 // qbitAPI is the subset of *qbittorrent.Client the adapter uses. It exists so
 // the import machinery can be unit-tested against a stub without a live client.
@@ -80,21 +83,42 @@ func (q *qbitClient) GetTorrents() ([]Torrent, error) {
 	return torrents, nil
 }
 
-func (q *qbitClient) GetFiles(hash string) ([]File, error) {
+func (q *qbitClient) GetFiles(hashes []string) []FileResult {
+	results := make([]FileResult, len(hashes))
+	if len(hashes) == 0 {
+		return results
+	}
+
+	jobs := make(chan int)
+	var workers sync.WaitGroup
+	for range min(qbitFileReadWorkers, len(hashes)) {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for index := range jobs {
+				results[index] = q.getFiles(hashes[index])
+			}
+		}()
+	}
+	for index := range hashes {
+		jobs <- index
+	}
+	close(jobs)
+	workers.Wait()
+	return results
+}
+
+func (q *qbitClient) getFiles(hash string) FileResult {
 	torrentFiles, err := q.c.GetFilesInformation(hash)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get files")
+		return FileResult{Hash: hash, Err: errors.Wrap(err, "failed to get files")}
 	}
 
 	files := make([]File, 0, len(*torrentFiles))
-	for _, f := range *torrentFiles {
-		files = append(files, File{
-			Name: f.Name,
-			Size: f.Size,
-		})
+	for _, file := range *torrentFiles {
+		files = append(files, File{Name: file.Name, Size: file.Size})
 	}
-
-	return files, nil
+	return FileResult{Hash: hash, Files: files}
 }
 
 // ImportDestination resolves the final import destination for this qBittorrent client.

--- a/internal/torrentclient/qbittorrent_test.go
+++ b/internal/torrentclient/qbittorrent_test.go
@@ -7,6 +7,7 @@ import (
 	stderrors "errors"
 	"maps"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -32,6 +33,13 @@ type stubQbitAPI struct {
 
 	recheckCalls [][]string
 	resumeCalls  [][]string
+
+	fileMu         sync.Mutex
+	filesByHash    map[string]qbittorrent.TorrentFiles
+	fileErrByHash  map[string]error
+	fileDelay      time.Duration
+	activeFileRead int
+	maxFileReads   int
 }
 
 func (s *stubQbitAPI) GetTorrents(o qbittorrent.TorrentFilterOptions) ([]qbittorrent.Torrent, error) {
@@ -47,8 +55,24 @@ func (s *stubQbitAPI) GetTorrents(o qbittorrent.TorrentFilterOptions) ([]qbittor
 	return []qbittorrent.Torrent{s.lookupSeq[idx]}, nil
 }
 
-func (s *stubQbitAPI) GetFilesInformation(string) (*qbittorrent.TorrentFiles, error) {
-	return &qbittorrent.TorrentFiles{}, nil
+func (s *stubQbitAPI) GetFilesInformation(hash string) (*qbittorrent.TorrentFiles, error) {
+	s.fileMu.Lock()
+	s.activeFileRead++
+	s.maxFileReads = max(s.maxFileReads, s.activeFileRead)
+	files := s.filesByHash[hash]
+	err := s.fileErrByHash[hash]
+	delay := s.fileDelay
+	s.fileMu.Unlock()
+
+	time.Sleep(delay)
+
+	s.fileMu.Lock()
+	s.activeFileRead--
+	s.fileMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return &files, nil
 }
 
 func (s *stubQbitAPI) AddTorrentFromMemory(buf []byte, options map[string]string) (*qbittorrent.TorrentAddResponse, error) {
@@ -88,6 +112,33 @@ func newTestQbitClient(stub *stubQbitAPI, policy domain.ImportPolicy) *qbitClien
 		recheckTimeout: time.Second,
 		pollInterval:   time.Millisecond,
 	}
+}
+
+func TestQbitGetFilesUsesBoundedOrderedReads(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubQbitAPI{
+		filesByHash: map[string]qbittorrent.TorrentFiles{
+			"one":   {{Name: "one.mkv", Size: 1}},
+			"two":   {{Name: "two.mkv", Size: 2}},
+			"three": {{Name: "three.mkv", Size: 3}},
+			"five":  {{Name: "five.mkv", Size: 5}},
+			"six":   {{Name: "six.mkv", Size: 6}},
+		},
+		fileErrByHash: map[string]error{"four": stderrors.New("not found")},
+		fileDelay:     10 * time.Millisecond,
+	}
+	client := newTestQbitClient(stub, domain.ImportPolicy{})
+	hashes := []string{"one", "two", "three", "four", "five", "six"}
+
+	results := client.GetFiles(hashes)
+	require.Len(t, results, len(hashes))
+	for index, hash := range hashes {
+		require.Equal(t, hash, results[index].Hash)
+	}
+	require.Equal(t, []File{{Name: "one.mkv", Size: 1}}, results[0].Files)
+	require.Error(t, results[3].Err)
+	require.Equal(t, qbitFileReadWorkers, stub.maxFileReads)
 }
 
 func TestQbitBuildTorrentAddOptions(t *testing.T) {

--- a/internal/torrentclient/transmission.go
+++ b/internal/torrentclient/transmission.go
@@ -107,29 +107,39 @@ func (t *transmissionClient) GetTorrents() ([]Torrent, error) {
 	return torrents, nil
 }
 
-func (t *transmissionClient) GetFiles(hash string) ([]File, error) {
+func (t *transmissionClient) GetFiles(hashes []string) []FileResult {
+	if len(hashes) == 0 {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), transmissionTimeout)
 	defer cancel()
 
-	ts, err := t.c.TorrentGetHashes(ctx, []string{"files"}, []string{hash})
+	ts, err := t.c.TorrentGetHashes(ctx, []string{"hashString", "files"}, hashes)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get files")
+		return fileResultsWithError(hashes, errors.Wrap(err, "failed to get files"))
 	}
 
-	if len(ts) == 0 {
-		return nil, fmt.Errorf("transmission: torrent not found: %s", hash)
+	filesByHash := make(map[string][]File, len(ts))
+	for _, torrent := range ts {
+		files := make([]File, 0, len(torrent.Files))
+		for _, file := range torrent.Files {
+			files = append(files, File{Name: file.Name, Size: file.Length})
+		}
+		filesByHash[strings.ToLower(derefString(torrent.HashString))] = files
 	}
 
-	rawFiles := ts[0].Files
-	files := make([]File, 0, len(rawFiles))
-	for _, f := range rawFiles {
-		files = append(files, File{
-			Name: f.Name,
-			Size: f.Length,
-		})
+	results := make([]FileResult, len(hashes))
+	for index, hash := range hashes {
+		results[index].Hash = hash
+		files, ok := filesByHash[strings.ToLower(hash)]
+		if !ok {
+			results[index].Err = fmt.Errorf("transmission: torrent not found: %s", hash)
+			continue
+		}
+		results[index].Files = files
 	}
-
-	return files, nil
+	return results
 }
 
 // ImportDestination resolves the final import destination for this transmission client:

--- a/internal/torrentclient/transmission_import_test.go
+++ b/internal/torrentclient/transmission_import_test.go
@@ -23,6 +23,7 @@ type stubTransmissionAPI struct {
 	statusSeq   []transmissionrpc.TorrentStatus
 	statusIdx   int
 	errorString string
+	getErr      error
 
 	sessionDir string
 }
@@ -32,6 +33,9 @@ func (s *stubTransmissionAPI) TorrentGet(context.Context, []string, []int64) ([]
 }
 
 func (s *stubTransmissionAPI) TorrentGetHashes(context.Context, []string, []string) ([]transmissionrpc.Torrent, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
 	if len(s.statusSeq) == 0 {
 		return nil, nil
 	}

--- a/internal/torrentclient/transmission_live_test.go
+++ b/internal/torrentclient/transmission_live_test.go
@@ -45,10 +45,11 @@ func TestTransmissionLive(t *testing.T) {
 	first := torrents[0]
 	t.Logf("first torrent: hash=%s name=%q savePath=%q", first.Hash, first.Name, first.SavePath)
 
-	files, err := c.GetFiles(first.Hash)
-	if err != nil {
-		t.Fatalf("GetFiles(%q): %v", first.Hash, err)
+	results := c.GetFiles([]string{first.Hash})
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("GetFiles(%q): %+v", first.Hash, results)
 	}
+	files := results[0].Files
 	t.Logf("GetFiles returned %d file(s)", len(files))
 	for i, f := range files {
 		t.Logf("  [%d] name=%q size=%d", i, f.Name, f.Size)

--- a/internal/torrentclient/transmission_test.go
+++ b/internal/torrentclient/transmission_test.go
@@ -5,6 +5,7 @@ package torrentclient
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -171,49 +172,69 @@ func TestTransmissionGetTorrents(t *testing.T) {
 
 func TestTransmissionGetFiles(t *testing.T) {
 	t.Parallel()
-	// Multi-file torrent: file paths include the top-level folder prefix.
-	const resp = `{"torrents":[{"files":[{"name":"Show.S01/E01.mkv","length":1000000},{"name":"Show.S01/E02.mkv","length":1050000}]}]}`
+	// The server response order differs from the requested hash order.
+	const resp = `{"torrents":[{"hashString":"DEF456","files":[{"name":"Other.S01/E01.mkv","length":2000000}]},{"hashString":"abc123","files":[{"name":"Show.S01/E01.mkv","length":1000000},{"name":"Show.S01/E02.mkv","length":1050000}]}]}`
 	srv, captured := transmissionTestServer(t, map[string]string{
 		"session-get": emptySessionResp,
 		"torrent-get": resp,
 	})
 	c := newTransmissionClientFromServer(t, srv, "", "")
 
-	files, err := c.GetFiles("abc123")
-	if err != nil {
-		t.Fatalf("GetFiles: %v", err)
+	results := c.GetFiles([]string{"abc123", "def456"})
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
 	}
-	if len(files) != 2 {
-		t.Fatalf("len(files) = %d, want 2", len(files))
+	if results[0].Err != nil || results[0].Hash != "abc123" || len(results[0].Files) != 2 {
+		t.Fatalf("results[0] = %+v, want abc123 with two files", results[0])
 	}
-	if files[0].Name != "Show.S01/E01.mkv" || files[0].Size != 1000000 {
-		t.Errorf("files[0] = %+v, want {Name:Show.S01/E01.mkv Size:1000000}", files[0])
+	if results[0].Files[0].Name != "Show.S01/E01.mkv" || results[0].Files[0].Size != 1000000 {
+		t.Errorf("results[0].Files[0] = %+v, want {Name:Show.S01/E01.mkv Size:1000000}", results[0].Files[0])
 	}
-	if files[1].Name != "Show.S01/E02.mkv" || files[1].Size != 1050000 {
-		t.Errorf("files[1] = %+v, want {Name:Show.S01/E02.mkv Size:1050000}", files[1])
+	if results[1].Err != nil || results[1].Hash != "def456" || len(results[1].Files) != 1 {
+		t.Fatalf("results[1] = %+v, want def456 with one file", results[1])
 	}
 
-	// Wire-format assertion: the hash is sent as the ids identifier, files requested.
+	// Wire-format assertion: both hashes use one request with identity and files.
 	req := lastRequest(t, captured, "torrent-get")
-	assertStringSlice(t, req.Arguments["fields"], []string{"files"})
-	assertStringSlice(t, req.Arguments["ids"], []string{"abc123"})
+	assertStringSlice(t, req.Arguments["fields"], []string{"hashString", "files"})
+	assertStringSlice(t, req.Arguments["ids"], []string{"abc123", "def456"})
 }
 
 func TestTransmissionGetFiles_NotFound(t *testing.T) {
 	t.Parallel()
-	const resp = `{"torrents":[]}`
+	const resp = `{"torrents":[{"hashString":"abc123","files":[{"name":"Show.S01/E01.mkv","length":1}]}]}`
 	srv, _ := transmissionTestServer(t, map[string]string{
 		"session-get": emptySessionResp,
 		"torrent-get": resp,
 	})
 	c := newTransmissionClientFromServer(t, srv, "", "")
 
-	_, err := c.GetFiles("notexist")
-	if err == nil {
+	results := c.GetFiles([]string{"abc123", "notexist"})
+	if len(results) != 2 || results[0].Err != nil {
+		t.Fatalf("results = %+v, want first hash to succeed", results)
+	}
+	if results[1].Err == nil {
 		t.Fatal("expected error for missing torrent, got nil")
 	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error = %q, want to contain 'not found'", err.Error())
+	if !strings.Contains(results[1].Err.Error(), "not found") {
+		t.Errorf("error = %q, want to contain 'not found'", results[1].Err.Error())
+	}
+}
+
+func TestTransmissionGetFilesExpandsWholeCallError(t *testing.T) {
+	t.Parallel()
+
+	errBoom := errors.New("boom")
+	client := newTestTransmissionClient(&stubTransmissionAPI{getErr: errBoom}, domain.ImportPolicy{})
+	results := client.GetFiles([]string{"one", "two"})
+
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	for index, hash := range []string{"one", "two"} {
+		if results[index].Hash != hash || !errors.Is(results[index].Err, errBoom) {
+			t.Errorf("results[%d] = %+v, want hash %q wrapping boom", index, results[index], hash)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #244

Followed by:
- #252
<!-- ship-stack:end -->

## Problem

Exact season-pack planning read file details one torrent at a time. Each candidate added a client round trip before matching could start.

## Change

- Add one ordered multi-hash file-read interface with per-hash errors.
- Use one Transmission bulk RPC and one Deluge v2 bulk RPC.
- Use a Deluge v1 session-state preflight before its bulk status RPC so unknown IDs cannot break wrapper decoding.
- Use four bounded qBittorrent workers because the pinned wrapper exposes only single-hash file reads.
- Keep successful candidate reads usable when another hash fails.

## Results

A real-client probe requested 24 successful results plus one missing hash. qBittorrent 5.2.3 completed it in 22.5 ms, Transmission 4.1.3 in 1.7 ms, Deluge 1.3.15 in 2.7 ms, and Deluge 2.1.2.dev0 in 1.4 ms on local Docker.

## Tests

- Ordered results, partial errors, missing hashes, and whole-call failures.
- qBittorrent four-worker concurrency limit.
- Transmission and Deluge request-count and response-order behavior.
- Live import and file-read probes for qBittorrent, Transmission, Deluge v1, and Deluge v2.