### PR TITLE
perf(release): index episode matching

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,7 @@
 
 - `/api/candidate` reads torrent summaries only. It does not need torrent bytes or file-detail calls.
 - `/api/pack` parses the announced torrent, maps reusable source files to distinct valid torrent targets, and applies smart mode to exact torrent coverage.
+- Exact plan matching parses each episode filename once and uses an indexed compatibility key instead of scanning every source-target pair.
 - Exact planning requests candidate file details once. Transmission and Deluge v2 batch hashes in one client call. Deluge v1 uses one session-state preflight and one bulk status call. qBittorrent uses a bounded four-worker adapter pool.
 - Client inventory is cached for 30 seconds, so the ordered candidate and pack checks normally share one client scan.
 - Accepted import plans are cached for 2 minutes. `/api/parse` normally performs no second inventory or file-detail reads.

--- a/docs/design-docs/matching-and-hardlinking.md
+++ b/docs/design-docs/matching-and-hardlinking.md
@@ -26,6 +26,14 @@ Current comparison logic checks:
 - changes to target path derivation need docs plus concrete verification notes
 - if behavior intentionally broadens acceptance, explain the user value and failure tradeoff
 
+## Planning Performance Expectations
+
+- parse each client and torrent episode filename once per exact plan
+- index targets by every safety-sensitive episode compatibility field
+- preserve torrent target order and first-source deduplication
+- request candidate file details once through the torrent-client interface
+- keep client-specific batching and concurrency inside each adapter
+
 ## Open Questions
 
 - whether additional sample/extension filtering is needed beyond current checks

--- a/docs/exec-plans/completed/2026-08-11-release-planning-performance.md
+++ b/docs/exec-plans/completed/2026-08-11-release-planning-performance.md
@@ -1,0 +1,106 @@
+# Release planning performance
+
+## goal
+
+Reduce exact season-pack planning CPU, allocations, and torrent-client round
+trips without changing release compatibility or hardlink selection.
+
+## scope
+
+- parse each client and pack episode filename once per plan
+- replace the candidate-by-target scan with an indexed exact match
+- preserve deterministic target ordering and cross-seed deduplication
+- research bulk file-detail reads in the exact qBittorrent, Transmission, and
+  Deluge client revisions used by this repository
+- design and implement the smallest torrent-client interface that lets each
+  adapter use its strongest safe read strategy
+- add behavior, call-count, and performance regression coverage
+
+## non-goals
+
+- changing resolution, group, container, size, season, or episode acceptance
+- changing candidate discovery or fuzzy matching behavior
+- changing cache lifetimes or import behavior
+- migrating the release parser module
+
+## risks
+
+- **False positives.** An incomplete index key could link an incompatible
+  episode. The key must contain every field checked by the current matcher.
+- **False negatives.** Duplicate keys and renamed files can make a single-value
+  index lose valid targets. The index must retain stable target order and the
+  exact parsed-file fallback behavior where required.
+- **Client overload.** Parallel per-hash reads can overload a remote client.
+  Each adapter must own batching or bounded concurrency behind one interface.
+- **Partial reads.** A bulk request can return some results and some failures.
+  Planning must keep the current best-effort candidate behavior and preserve
+  useful per-torrent errors.
+
+## steps
+
+1. Record current matching behavior and benchmark baselines. [done]
+2. Add a parsed episode-file representation and indexed target matcher in
+   `internal/release`. [done]
+3. Integrate the index into exact import planning and preserve link ordering.
+   [done]
+4. Add regression tests and persistent benchmarks for 12, 24, and 100 episode
+   plans. [done]
+5. Audit primary client and library source for bulk file-detail capabilities.
+   [done]
+6. Select and implement the torrent-client file-read interface. [done]
+7. Run focused formatting, tests, race checks, benchmarks, and documentation
+   review. Move this plan to completed. [done]
+
+## decision log
+
+- 2026-08-11: keep indexed CPU matching and client read reduction in one PR.
+  Both changes are local to exact plan construction and share the same
+  behavior and performance verification surface.
+- 2026-08-11: supersede the single-PR packaging decision. Ship client file-read
+  batching first, then stack the parse-once indexed matcher on it. The
+  torrent-client seam keeps the two implementations independently reviewable.
+- 2026-08-11: place parsed episode matching in the release module. The HTTP
+  processor should orchestrate candidates and links without knowing parser
+  fields or normalization rules.
+- 2026-08-11: keep client-specific batching and concurrency behind the
+  torrent-client seam. The processor should request candidate file details once
+  without selecting an adapter strategy.
+- 2026-08-11: `GetFiles` returns one ordered `FileResult` per input hash.
+  Per-hash errors preserve successful reads and the existing best-effort plan
+  behavior.
+- 2026-08-11: Transmission and Deluge v2 use one native multi-hash request.
+  Deluge v1 first filters IDs through `SessionState` because an unknown ID
+  causes the pinned wrapper to fail while decoding an empty status dictionary.
+  qBittorrent uses four concurrent single-hash requests because the pinned Go
+  wrapper does not expose the qBittorrent 5.2 bulk file response.
+
+## verification notes
+
+- Baseline synthetic benchmark on Apple M4 Pro, Go 1.26.5: current nested
+  matching took about 12.7 ms for 12 episodes, 48.6 ms for 24 episodes, and
+  823 ms for 100 episodes.
+- A temporary parse-once map prototype took about 2.04 ms, 4.09 ms, and 17.0
+  ms for the same cases. Temporary benchmark files were removed after the run.
+- The checked-in matcher benchmark measures about 1.97 ms, 3.96 ms, and 16.8
+  ms for 12, 24, and 100 episodes. The 100-episode case drops from about 72 MB
+  and 1.05 million allocations to 3.5 MB and 24,000 allocations.
+- `go test ./...` passed after indexed matching was integrated.
+- `go test -race ./internal/release ./internal/http` passed.
+- Primary-source client findings are recorded in
+  `docs/references/torrent-client-file-read-performance.md`.
+- Focused torrent-client, HTTP, and release tests pass after bulk file reads.
+- `go test -race ./internal/release ./internal/http ./internal/torrentclient`
+  passed.
+- `gofumpt -w .`, `go test -v ./...`, `go vet ./...`, and
+  `git diff --check` passed.
+- Final checked-in benchmark medians: indexed matching takes about 1.89 ms for
+  12 episodes, 3.79 ms for 24 episodes, and 15.9 ms for 100 episodes. The
+  corresponding nested scan takes about 12.2 ms, 46.1 ms, and 778 ms.
+- `govulncheck ./...` found no vulnerabilities in called code or imported
+  packages. One required-module vulnerability is not called.
+- Disposable live-client tests passed against qBittorrent 5.2.3, Transmission
+  4.1.3, Deluge 1.3.15, and Deluge 2.1.2.dev0. Each adapter imported complete
+  and partial torrents. The file-read probe requested 24 successful results and
+  one missing result. Observed probe times were 22.5 ms, 1.7 ms, 2.7 ms, and
+  1.4 ms respectively. This probe validates request shape and compatibility. It
+  is not a sustained-throughput benchmark.

--- a/internal/http/processor_plan.go
+++ b/internal/http/processor_plan.go
@@ -108,10 +108,10 @@ func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client,
 	if err != nil {
 		return importPlan{}, domain.StatusGetEpisodesError, fmt.Errorf("%s: %w", domain.StatusGetEpisodesError, err)
 	}
-	eligibleEps := torrentEps[:0]
+	eligibleEps := make([]release.EpisodeFile, 0, len(torrentEps))
 	for _, torrentEp := range torrentEps {
-		if release.IsValidEpisodeFile(torrentEp.Path) {
-			eligibleEps = append(eligibleEps, torrentEp)
+		if episode, ok := release.ParseEpisodeFile(torrentEp.Path, torrentEp.Size); ok {
+			eligibleEps = append(eligibleEps, episode)
 		}
 	}
 	if len(eligibleEps) == 0 {
@@ -123,52 +123,18 @@ func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client,
 		return importPlan{}, domain.StatusParseTorrentInfoError, fmt.Errorf("%s: %w", domain.StatusParseTorrentInfoError, err)
 	}
 
-	fileResults := p.getFiles(candidates)
-	linksByTarget := make(map[string]plannedLink)
-	for index, candidate := range candidates {
-		if index >= len(fileResults) {
-			p.log.Error().Msgf("torrent client omitted file result for %s", candidate.torrent.Name)
-			continue
-		}
-
-		result := fileResults[index]
-		if !strings.EqualFold(result.Hash, candidate.torrent.Hash) {
-			p.log.Error().Msgf("torrent client returned out-of-order file result for %s", candidate.torrent.Name)
-			continue
-		}
-		if result.Err != nil {
-			p.log.Error().Err(result.Err).Msgf("error getting file info: %s", candidate.torrent.Name)
-			continue
-		}
-
-		fileName, size, err := episodeFileFromFiles(result.Files)
-		if err != nil {
-			p.log.Error().Err(err).Msgf("error getting file info: %s", candidate.torrent.Name)
-			continue
-		}
-		clientEpPath := filepath.Join(candidate.torrent.SavePath, fileName)
-
-		for _, torrentEp := range eligibleEps {
-			matchedEpPath, _ := release.MatchEpToSeasonPackEp(clientEpPath, size, torrentEp.Path, torrentEp.Size)
-			if matchedEpPath == "" {
-				continue
-			}
-			if _, exists := linksByTarget[matchedEpPath]; !exists {
-				linksByTarget[matchedEpPath] = plannedLink{clientEpPath: clientEpPath, torrentEpPath: matchedEpPath}
-			}
-			break
-		}
-	}
-
-	if len(linksByTarget) == 0 {
+	matcher := release.NewEpisodeMatcher(eligibleEps)
+	matches := matcher.Match(p.getEpisodeFiles(candidates))
+	if len(matches) == 0 {
 		return importPlan{}, domain.StatusFailedMatchToTorrentEps, domain.StatusFailedMatchToTorrentEps.Error()
 	}
 
-	links := make([]plannedLink, 0, len(linksByTarget))
-	for _, torrentEp := range eligibleEps {
-		if link, ok := linksByTarget[torrentEp.Path]; ok {
-			links = append(links, link)
-		}
+	links := make([]plannedLink, 0, len(matches))
+	for _, match := range matches {
+		links = append(links, plannedLink{
+			clientEpPath:  match.ClientPath,
+			torrentEpPath: match.TorrentPath,
+		})
 	}
 
 	return importPlan{
@@ -180,34 +146,53 @@ func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client,
 	}, domain.StatusSuccessfulMatch, nil
 }
 
-func (p *processor) getFiles(candidates []entry) []torrentclient.FileResult {
+func (p *processor) getEpisodeFiles(candidates []entry) []release.EpisodeFile {
 	hashes := make([]string, len(candidates))
 	for index, candidate := range candidates {
 		hashes[index] = candidate.torrent.Hash
 	}
-	return p.req.Client.GetFiles(hashes)
-}
 
-func episodeFileFromFiles(torrentFiles []torrentclient.File) (string, int64, error) {
-	var fileName string
-	var size int64
-	for _, f := range torrentFiles {
-		if !release.IsValidEpisodeFile(f.Name) {
+	results := p.req.Client.GetFiles(hashes)
+	episodes := make([]release.EpisodeFile, 0, len(results))
+	for index, candidate := range candidates {
+		if index >= len(results) {
+			p.log.Error().Msgf("torrent client omitted file result for %s", candidate.torrent.Name)
 			continue
 		}
 
-		fileName = f.Name
-		size = f.Size
-		break
+		result := results[index]
+		if !strings.EqualFold(result.Hash, candidate.torrent.Hash) {
+			p.log.Error().Msgf("torrent client returned out-of-order file result for %s", candidate.torrent.Name)
+			continue
+		}
+		if result.Err != nil {
+			p.log.Error().Err(result.Err).Msgf("error getting file info: %s", candidate.torrent.Name)
+			continue
+		}
+
+		episode, err := episodeFileFromFiles(result.Files, candidate.torrent.SavePath)
+		if err != nil {
+			p.log.Error().Err(err).Msgf("error getting file info: %s", candidate.torrent.Name)
+			continue
+		}
+		episodes = append(episodes, episode)
 	}
-	switch {
-	case len(fileName) == 0:
-		return "", 0, errors.New("file name is empty")
-	case size == 0:
-		return "", 0, errors.New("file size is empty")
+	return episodes
+}
+
+func episodeFileFromFiles(files []torrentclient.File, savePath string) (release.EpisodeFile, error) {
+	for _, f := range files {
+		episode, ok := release.ParseEpisodeFile(filepath.Join(savePath, f.Name), f.Size)
+		if !ok {
+			continue
+		}
+		if f.Size == 0 {
+			return release.EpisodeFile{}, errors.New("file size is empty")
+		}
+		return episode, nil
 	}
 
-	return fileName, size, nil
+	return release.EpisodeFile{}, errors.New("file name is empty")
 }
 
 func importPlanKey(clientName string, hashes torrents.Hashes) importPlanCacheKey {

--- a/internal/http/processor_test.go
+++ b/internal/http/processor_test.go
@@ -384,9 +384,9 @@ func newTestProcessor(client torrentclient.TorrentClient) *processor {
 // torrentclient.TorrentClient: the hardlink source the processor uses is
 // filepath.Join(Torrent.SavePath, <file name from GetFiles>). File names keep
 // their torrent-root-folder prefix and SavePath is the absolute on-disk download
-// dir, so the join is the real file path. A future TorrentClient implementation
-// that returns a bare basename or a non-absolute SavePath would break hardlinking
-// silently — this test fails first.
+// dir, so the parsed episode path is the real file path. A future TorrentClient
+// implementation that returns a bare basename or a non-absolute SavePath would
+// break hardlinking silently. This test fails first.
 func TestTorrentClientPathContract(t *testing.T) {
 	const savePath = "/data/torrents/tv"
 	mock := &mockTorrentClient{
@@ -407,29 +407,24 @@ func TestTorrentClientPathContract(t *testing.T) {
 		t.Fatalf("len(torrents) = %d, want 1", len(ts))
 	}
 
-	results := p.getFiles([]entry{{torrent: ts[0]}})
-	if len(results) != 1 || results[0].Err != nil {
-		t.Fatalf("getFiles: %+v", results)
-	}
-	fileName, size, err := episodeFileFromFiles(results[0].Files)
+	results := p.req.Client.GetFiles([]string{ts[0].Hash})
+	require.Len(t, results, 1)
+	require.NoError(t, results[0].Err)
+	episode, err := episodeFileFromFiles(results[0].Files, ts[0].SavePath)
 	if err != nil {
-		t.Fatalf("episodeFileFromFiles: %v", err)
+		t.Fatalf("getEpisodeFile: %v", err)
 	}
 	if mock.gotHash != "abc123" {
 		t.Errorf("GetFiles called with hash %q, want abc123", mock.gotHash)
 	}
-	if size != 1_000_000 {
-		t.Errorf("size = %d, want 1000000", size)
-	}
-
-	gotSource := filepath.Join(ts[0].SavePath, fileName)
+	gotSource := episode.Path()
 	const wantSource = "/data/torrents/tv/Some.Show.S01.1080p/Some.Show.S01E01.1080p.mkv"
 	if gotSource != wantSource {
 		t.Errorf("hardlink source = %q, want %q", gotSource, wantSource)
 	}
 }
 
-func TestGetFilesSelectsFirstValidEpisode(t *testing.T) {
+func TestGetEpisodeFileSelectsFirstValidEpisode(t *testing.T) {
 	mock := &mockTorrentClient{
 		files: []torrentclient.File{
 			{Name: "Some.Show.S01/poster.jpg", Size: 50},                  // not a video
@@ -437,38 +432,46 @@ func TestGetFilesSelectsFirstValidEpisode(t *testing.T) {
 			{Name: "Some.Show.S01/Some.Show.S01E02.mkv", Size: 1_100_000},
 		},
 	}
-	fileName, size, err := episodeFileFromFiles(mock.files)
+	episode, err := episodeFileFromFiles(mock.files, "")
 	if err != nil {
-		t.Fatalf("getFiles: %v", err)
+		t.Fatalf("getEpisodeFile: %v", err)
 	}
-	if fileName != "Some.Show.S01/Some.Show.S01E01.mkv" {
-		t.Errorf("fileName = %q, want Some.Show.S01/Some.Show.S01E01.mkv", fileName)
-	}
-	if size != 1_000_000 {
-		t.Errorf("size = %d, want 1000000", size)
+	if episode.Path() != "Some.Show.S01/Some.Show.S01E01.mkv" {
+		t.Errorf("episode path = %q, want Some.Show.S01/Some.Show.S01E01.mkv", episode.Path())
 	}
 }
 
-func TestGetFilesErrorsWhenNoValidEpisode(t *testing.T) {
+func TestGetEpisodeFileErrorsWhenNoValidEpisode(t *testing.T) {
 	mock := &mockTorrentClient{
 		files: []torrentclient.File{
 			{Name: "Some.Show.S01/poster.jpg", Size: 50},
 			{Name: "Some.Show.S01/readme.txt", Size: 10},
 		},
 	}
-	if _, _, err := episodeFileFromFiles(mock.files); err == nil {
+	if _, err := episodeFileFromFiles(mock.files, ""); err == nil {
 		t.Fatal("expected error when no valid episode file is present, got nil")
 	}
 }
 
-func TestGetFilesPropagatesClientError(t *testing.T) {
-	errBoom := errors.New("boom")
-	p := newTestProcessor(&mockTorrentClient{filesErr: errBoom})
-
-	results := p.getFiles([]entry{{torrent: torrentclient.Torrent{Hash: "h"}}})
-	if len(results) != 1 || !errors.Is(results[0].Err, errBoom) {
-		t.Fatalf("getFiles result = %+v, want it to wrap errBoom", results)
+func TestGetEpisodeFilesKeepsSuccessfulBulkResults(t *testing.T) {
+	mock := &mockTorrentClient{
+		filesByHash: map[string][]torrentclient.File{
+			"one": {{Name: "Show.S01E01.1080p.WEB-DL-GROUP.mkv", Size: 100}},
+		},
+		fileErrByHash: map[string]error{"two": errors.New("boom")},
 	}
+	p := newTestProcessor(mock)
+	candidates := []entry{
+		{torrent: torrentclient.Torrent{Hash: "one", Name: "Show.S01E01", SavePath: "/one"}},
+		{torrent: torrentclient.Torrent{Hash: "two", Name: "Show.S01E02", SavePath: "/two"}},
+	}
+
+	episodes := p.getEpisodeFiles(candidates)
+	require.Len(t, episodes, 1)
+	require.Equal(t, "/one/Show.S01E01.1080p.WEB-DL-GROUP.mkv", episodes[0].Path())
+	require.Equal(t, 1, mock.fileBatchCalls)
+	require.Equal(t, 2, mock.fileCalls)
+	require.Equal(t, []string{"one", "two"}, mock.gotHashes)
 }
 
 func resetProcessorGlobals() {

--- a/internal/release/episode.go
+++ b/internal/release/episode.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package release
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/autobrr/rls"
+)
+
+type episodeMatchKey struct {
+	size       int64
+	ext        string
+	series     int
+	episode    int
+	resolution string
+	group      string
+}
+
+// EpisodeFile is a valid parsed episode video. Its parser details stay private
+// so callers cannot construct a partially normalized matching value.
+type EpisodeFile struct {
+	path string
+	key  episodeMatchKey
+}
+
+// ParseEpisodeFile validates and parses one episode video for indexed matching.
+// It checks the container before invoking the release parser so obvious
+// non-video files stay on the cheap path.
+func ParseEpisodeFile(path string, size int64) (EpisodeFile, bool) {
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+	if ext != "mkv" && ext != "mp4" {
+		return EpisodeFile{}, false
+	}
+
+	parsed := parseEpisodeFile(path)
+	if parsed.Type != rls.Episode && len(parsed.SeriesEpisodes()) == 0 {
+		return EpisodeFile{}, false
+	}
+
+	group := rls.MustNormalize(parsed.Group)
+	if group == "sample" {
+		return EpisodeFile{}, false
+	}
+
+	return EpisodeFile{
+		path: path,
+		key: episodeMatchKey{
+			size:       size,
+			ext:        ext,
+			series:     parsed.Series,
+			episode:    parsed.Episode,
+			resolution: parsed.Resolution,
+			group:      group,
+		},
+	}, true
+}
+
+// Path returns the original path supplied to ParseEpisodeFile.
+func (f EpisodeFile) Path() string {
+	return f.path
+}
+
+// EpisodeMatch maps one reusable client episode to one announced torrent
+// target.
+type EpisodeMatch struct {
+	ClientPath  string
+	TorrentPath string
+}
+
+// EpisodeMatcher indexes valid torrent targets once. Duplicate target keys keep
+// the first target, matching the former stable nested-scan behavior.
+type EpisodeMatcher struct {
+	targets          []EpisodeFile
+	firstTargetByKey map[episodeMatchKey]int
+}
+
+func NewEpisodeMatcher(targets []EpisodeFile) EpisodeMatcher {
+	matcher := EpisodeMatcher{
+		targets:          targets,
+		firstTargetByKey: make(map[episodeMatchKey]int, len(targets)),
+	}
+	for index, target := range targets {
+		if _, exists := matcher.firstTargetByKey[target.key]; !exists {
+			matcher.firstTargetByKey[target.key] = index
+		}
+	}
+	return matcher
+}
+
+func (m EpisodeMatcher) Len() int {
+	return len(m.targets)
+}
+
+// Match returns at most one client source per torrent target. Results follow
+// torrent target order, independent of client inventory order.
+func (m EpisodeMatcher) Match(sources []EpisodeFile) []EpisodeMatch {
+	clientPathByTarget := make(map[int]string, min(len(sources), len(m.targets)))
+	for _, source := range sources {
+		targetIndex, ok := m.firstTargetByKey[source.key]
+		if !ok {
+			continue
+		}
+		if _, exists := clientPathByTarget[targetIndex]; !exists {
+			clientPathByTarget[targetIndex] = source.path
+		}
+	}
+
+	matches := make([]EpisodeMatch, 0, len(clientPathByTarget))
+	for targetIndex, target := range m.targets {
+		clientPath, ok := clientPathByTarget[targetIndex]
+		if !ok {
+			continue
+		}
+		matches = append(matches, EpisodeMatch{
+			ClientPath:  clientPath,
+			TorrentPath: target.path,
+		})
+	}
+	return matches
+}

--- a/internal/release/episode_test.go
+++ b/internal/release/episode_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package release
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEpisodeMatcherChecksEveryCompatibilityField(t *testing.T) {
+	t.Parallel()
+
+	target := requireEpisodeFile(t, "Show.S01/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100)
+	sources := []EpisodeFile{
+		requireEpisodeFile(t, "/client/Show.S01E01.1080p.WEB-DL-GROUP.mp4", 100),
+		requireEpisodeFile(t, "/client/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 101),
+		requireEpisodeFile(t, "/client/Show.S02E01.1080p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "/client/Show.S01E02.1080p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "/client/Show.S01E01.2160p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "/client/Show.S01E01.1080p.WEB-DL-OTHER.mkv", 100),
+		requireEpisodeFile(t, "/client/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+	}
+
+	matches := NewEpisodeMatcher([]EpisodeFile{target}).Match(sources)
+	require.Equal(t, []EpisodeMatch{{
+		ClientPath:  "/client/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
+		TorrentPath: "Show.S01/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
+	}}, matches)
+}
+
+func TestEpisodeMatcherPreservesTargetOrderAndDeduplicatesSources(t *testing.T) {
+	t.Parallel()
+
+	targets := []EpisodeFile{
+		requireEpisodeFile(t, "Show.S01/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "Show.S01/Show.S01E02.1080p.WEB-DL-GROUP.mkv", 200),
+	}
+	sources := []EpisodeFile{
+		requireEpisodeFile(t, "/client/Show.S01E02.1080p.WEB-DL-GROUP.mkv", 200),
+		requireEpisodeFile(t, "/first/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "/second/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+	}
+
+	matches := NewEpisodeMatcher(targets).Match(sources)
+	require.Equal(t, []EpisodeMatch{
+		{
+			ClientPath:  "/first/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
+			TorrentPath: "Show.S01/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
+		},
+		{
+			ClientPath:  "/client/Show.S01E02.1080p.WEB-DL-GROUP.mkv",
+			TorrentPath: "Show.S01/Show.S01E02.1080p.WEB-DL-GROUP.mkv",
+		},
+	}, matches)
+}
+
+func TestEpisodeMatcherKeepsFirstDuplicateTarget(t *testing.T) {
+	t.Parallel()
+
+	targets := []EpisodeFile{
+		requireEpisodeFile(t, "first/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "second/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+	}
+	sources := []EpisodeFile{
+		requireEpisodeFile(t, "/client-a/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "/client-b/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+	}
+
+	matches := NewEpisodeMatcher(targets).Match(sources)
+	require.Equal(t, []EpisodeMatch{{
+		ClientPath:  "/client-a/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
+		TorrentPath: "first/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
+	}}, matches)
+}
+
+func BenchmarkEpisodeMatching(b *testing.B) {
+	for _, episodeCount := range []int{12, 24, 100} {
+		b.Run(fmt.Sprintf("nested_%d", episodeCount), func(b *testing.B) {
+			clientPaths, torrentPaths := benchmarkEpisodePaths(episodeCount)
+			b.ResetTimer()
+			for b.Loop() {
+				for _, clientPath := range clientPaths {
+					for _, torrentPath := range torrentPaths {
+						matched, _ := MatchEpToSeasonPackEp(clientPath, 2_000_000_000, torrentPath, 2_000_000_000)
+						if matched != "" {
+							break
+						}
+					}
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("indexed_%d", episodeCount), func(b *testing.B) {
+			clientPaths, torrentPaths := benchmarkEpisodePaths(episodeCount)
+			b.ResetTimer()
+			for b.Loop() {
+				targets := make([]EpisodeFile, 0, episodeCount)
+				for _, path := range torrentPaths {
+					target, _ := ParseEpisodeFile(path, 2_000_000_000)
+					targets = append(targets, target)
+				}
+				matcher := NewEpisodeMatcher(targets)
+
+				sources := make([]EpisodeFile, 0, episodeCount)
+				for _, path := range clientPaths {
+					source, _ := ParseEpisodeFile(path, 2_000_000_000)
+					sources = append(sources, source)
+				}
+				_ = matcher.Match(sources)
+			}
+		})
+	}
+}
+
+func requireEpisodeFile(t *testing.T, path string, size int64) EpisodeFile {
+	t.Helper()
+	episode, ok := ParseEpisodeFile(path, size)
+	require.True(t, ok, "ParseEpisodeFile(%q)", path)
+	return episode
+}
+
+func benchmarkEpisodePaths(episodeCount int) ([]string, []string) {
+	clientPaths := make([]string, episodeCount)
+	torrentPaths := make([]string, episodeCount)
+	for index := range episodeCount {
+		clientPaths[index] = fmt.Sprintf("/data/tv/Show.S01E%02d.1080p.WEB-DL.DDP5.1.H.264-GROUP.mkv", index+1)
+		torrentPaths[index] = fmt.Sprintf("Show.S01/Show.S01E%02d.1080p.WEB-DL.DDP5.1.H.264-GROUP.mkv", index+1)
+	}
+	return clientPaths, torrentPaths
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -165,22 +165,8 @@ func PercentOfTotalEpisodes(totalEps int, foundEps int) float32 {
 }
 
 func IsValidEpisodeFile(torrentFileName string) bool {
-	torrentFileRls := parseEpisodeFile(torrentFileName)
-
-	// ignore non video files
-	if !strings.EqualFold(torrentFileRls.Ext, "mkv") && !strings.EqualFold(torrentFileRls.Ext, "mp4") {
-		return false
-	}
-	if torrentFileRls.Type != rls.Episode && len(torrentFileRls.SeriesEpisodes()) == 0 {
-		return false
-	}
-
-	// ignore sample files
-	if rls.MustNormalize(torrentFileRls.Group) == "sample" {
-		return false
-	}
-
-	return true
+	_, ok := ParseEpisodeFile(torrentFileName, 0)
+	return ok
 }
 
 func parseEpisodeFile(path string) rls.Release {


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #251

Followed by:
- #253
<!-- ship-stack:end -->

## Problem

Exact planning parsed the same release names inside a nested source-by-target scan. CPU time and allocations grew rapidly with larger seasons and candidate sets.

## Change

- Parse each valid client and torrent episode once.
- Index torrent targets by all existing safety-sensitive compatibility fields.
- Preserve target order, first-source selection, duplicate target behavior, container checks, size checks, resolution, series and episode identity, and normalized release group.
- Keep parser details private inside the release module.
- Exclude early-stop and load-test work.

## Results

On Apple M4 Pro with Go 1.26.5, the 100-episode benchmark decreased from about 815-848 ms to 17-18 ms. Allocations decreased from about 1.05 million to about 24,000. Allocated bytes decreased from about 72-74 MB to about 3.4-3.7 MB.

## Tests

- Stable target order and first-source selection.
- Duplicate target compatibility behavior.
- Indexed matcher parity with the former nested matcher.
- Persistent 12, 24, and 100 episode benchmarks.
- `go test -v ./...`
- `go test -race ./internal/release ./internal/http`
- `go vet ./...`
- `git diff --check`
