### PR TITLE
feat: explain pack and import work

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,6 +56,9 @@
 - Accepted import plans are cached for 2 minutes. `/api/parse` normally performs no second inventory or file-detail reads.
 - Cache entries validate client configuration, matching settings, release name, and torrent identity. `/api/parse` rebuilds safely on a cache miss.
 - A successful import invalidates the plan and the client inventory.
+- Exact plans retain one compact reason for every unmatched torrent target.
+  Torrent-client adapters return neutral stage timings for successful and failed
+  imports. The HTTP processor owns the operator-facing structured logs.
 
 ### File Operations
 

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -7,9 +7,9 @@ Design docs capture stable reasoning about how this system should work.
 | Doc | Purpose | Verification Status | Last Reviewed |
 | --- | --- | --- | --- |
 | `core-beliefs.md` | Agent-first operating beliefs for this repo | Verified against repo structure and workflows | 2026-08-09 |
-| `season-pack-lifecycle.md` | End-to-end processing model from webhook to hardlink | Verified against `cmd/start.go`, `internal/http/*`, `internal/release/*` | 2026-08-09 |
-| `matching-and-hardlinking.md` | Safety and correctness constraints for matching and file linking | Verified against `internal/release/*`, `internal/files/*` | 2026-03-14 |
-| `qbittorrent-import-flow.md` | `/api/parse` client import flow (complete vs partial pack) with diagrams | Verified against `internal/torrentclient/*`, live qBittorrent 5.x / Transmission, Deluge 1.3.15, and Deluge 2.1.2 | 2026-08-08 |
+| `season-pack-lifecycle.md` | End-to-end processing and operator log model from webhook to import | Verified against `cmd/start.go`, `internal/http/*`, `internal/release/*` | 2026-08-12 |
+| `matching-and-hardlinking.md` | Safety, diagnostics, and correctness constraints for matching and file linking | Verified against `internal/release/*`, `internal/files/*` | 2026-08-12 |
+| `qbittorrent-import-flow.md` | `/api/parse` client import flow, timings, and complete-vs-partial behavior | Verified against `internal/torrentclient/*`, live qBittorrent 5.x / Transmission, Deluge 1.3.15, and Deluge 2.1.2 | 2026-08-12 |
 
 ## Usage
 

--- a/docs/design-docs/matching-and-hardlinking.md
+++ b/docs/design-docs/matching-and-hardlinking.md
@@ -34,6 +34,29 @@ Current comparison logic checks:
 - request candidate file details once through the torrent-client interface
 - keep client-specific batching and concurrency inside each adapter
 
+## Match Diagnostics
+
+Exact matching returns successful links and one diagnostic for every unmatched
+torrent target. The indexed success path remains the source of truth. The
+diagnostic pass runs only for unmatched targets and must not change selection.
+
+Diagnostics use these classifications:
+
+- `source_episode_not_found`: no parsed client source has the same season and
+  episode identity
+- `compatibility_mismatch`: the closest same-episode source differs by size,
+  container, resolution, or release group
+- `duplicate_torrent_target`: the torrent contains another target with the same
+  exact compatibility key and only the first target receives a source
+
+Compatibility diagnostics report each differing field with `want` and `got`
+values. `want` is the announced torrent target requirement. `got` is the value
+from the closest same-episode client source.
+
+Log one summary per unmatched target. Do not log every failed source-target
+comparison. The full comparison matrix produces noisy quadratic output and can
+undo the indexed planner's performance benefit.
+
 ## Open Questions
 
 - whether additional sample/extension filtering is needed beyond current checks

--- a/docs/design-docs/qbittorrent-import-flow.md
+++ b/docs/design-docs/qbittorrent-import-flow.md
@@ -38,9 +38,12 @@ flowchart TD
     N --> M
 ```
 
-Any step that fails returns a stage-tagged `*ImportError` (`config` / `add` /
-`find` / `recheck` / `resume`) which the processor maps to a status code
-(459–463) without ever seeing a qBittorrent type.
+Every return includes a neutral `ImportReport` with attempted stage durations.
+Any step that fails also returns a stage-tagged `*ImportError` (`config` /
+`add` / `find` / `recheck` / `resume`) which the processor maps to a status
+code (459–463) without ever seeing a qBittorrent type. The processor logs the
+report, so an operator can distinguish add latency from torrent discovery,
+recheck, and resume latency.
 
 Category-only policy sends the category without `savepath` or `autoTMM`, so
 qBittorrent keeps its own path-selection and automatic-management behavior.
@@ -75,7 +78,7 @@ sequenceDiagram
     opt not already active
         A->>Q: Resume(hash)
     end
-    A-->>P: nil (imported and started)
+    A-->>P: ImportReport (imported and started)
 ```
 
 The single difference between the two runs is whether the added torrent lands in

--- a/docs/design-docs/season-pack-lifecycle.md
+++ b/docs/design-docs/season-pack-lifecycle.md
@@ -21,7 +21,9 @@ Describe the normal path from webhook hit to hardlink creation and client import
 13. The torrent is added to the client, checked so the present files are recognised, and not left paused. See
     [qbittorrent-import-flow.md](qbittorrent-import-flow.md) for the complete-vs-partial
     client import flow with diagrams.
-14. Logs and notifications communicate outcome.
+14. Pack logs explain unmatched torrent targets. Parse logs report plan reuse,
+    hardlink work, client-import stage durations, and total duration.
+    Notifications communicate the final outcome.
 
 ## Failure Classes
 
@@ -35,4 +37,4 @@ Describe the normal path from webhook hit to hardlink creation and client import
 
 ## Verification Notes
 
-Verified against code on 2026-08-09. The lifecycle is implementation-backed, not aspirational.
+Verified against code on 2026-08-12. The lifecycle is implementation-backed, not aspirational.

--- a/docs/exec-plans/completed/2026-08-12-observability-consistency.md
+++ b/docs/exec-plans/completed/2026-08-12-observability-consistency.md
@@ -1,0 +1,64 @@
+# Observability consistency follow-up
+
+## goal
+
+Make candidate, pack, and parse diagnostics follow the operator log contract
+without hiding original comparison values or expected gate outcomes.
+
+## scope
+
+- preserve original candidate `want` and `got` values during fuzzy comparison
+- log successful and failed import-destination resolution at `INFO`
+- classify expected pack rejections as informational events
+- remove the superseded formatted hardlink summary
+- add authenticated HTTP and release-comparison regression coverage
+- update the operator log contract
+
+## non-goals
+
+- changing matching or threshold acceptance
+- creating one common event envelope for every HTTP log
+- changing configured log levels
+- changing request or response payloads
+
+## risks
+
+- **Diagnostic drift.** Raw log values must not change normalized acceptance.
+- **Outcome drift.** Only expected gate decisions can move from error to info.
+- **Missing failure time.** Destination failures must retain duration and error.
+
+## steps
+
+1. Preserve raw candidate mismatch values. [done]
+2. Log every destination-resolution attempt at `INFO`. [done]
+3. Align expected pack rejection levels with candidate. [done]
+4. Remove the duplicate hardlink summary. [done]
+5. Update docs and verify affected packages and the full repository. [done]
+6. Review standards and specification axes, address findings, and commit. [done]
+
+## decision log
+
+- 2026-08-12: use authenticated HTTP logs as the operator-facing test seam.
+- 2026-08-12: use the release comparison seam to prove fuzzy matching still
+  accepts normalized values while diagnostics retain original values.
+- 2026-08-12: keep the existing event interfaces. Do not introduce a general
+  logging wrapper for five local fixes.
+
+## verification notes
+
+- Candidate fuzzy-source and HDR tests prove original diagnostic values and
+  unchanged normalized acceptance.
+- Authenticated HTTP tests cover candidate diagnostics, destination success and
+  failure, expected pack rejections, and removal of the duplicate summary.
+- `gofumpt -w .` and `git diff --check` pass.
+- `go test -v ./...` passes. Environment-gated live-client tests are skipped
+  because their external test environments are not configured.
+- `go test -race ./internal/release ./internal/http` passes.
+- `go vet ./...` passes.
+- `govulncheck ./...` reports no called-code or imported-package
+  vulnerabilities. One required-module vulnerability is not called.
+- Final standards review found no hard violations. Its test-helper duplication
+  judgment call was rejected because local setup is clearer than another test
+  abstraction.
+- Final specification review found missing normalized-acceptance assertions.
+  WEB and HDR acceptance cases were added and pass.

--- a/docs/exec-plans/completed/2026-08-12-pack-import-observability.md
+++ b/docs/exec-plans/completed/2026-08-12-pack-import-observability.md
@@ -1,0 +1,90 @@
+# Pack and import observability
+
+## goal
+
+Make `/api/pack` explain every torrent episode that cannot be reused. Make
+`/api/parse` explain where client-import time is spent.
+
+## scope
+
+- return compact unmatched-target diagnostics from exact episode matching
+- preserve indexed matching performance and deterministic match selection
+- log one structured event per unmatched torrent target
+- return neutral attempted-stage timing from each torrent-client adapter,
+  including the stage that failed
+- log plan source, hardlink duration, client-import stages, and total parse time
+- add matcher, adapter, and authenticated HTTP regression coverage
+- update operator and design documentation
+
+## non-goals
+
+- changing episode compatibility or smart-mode acceptance
+- restoring the old source-by-target mismatch log flood
+- adding configuration or changing log levels
+- reading or logging torrent-client credentials
+
+## risks
+
+- **False explanations.** Diagnostics must not claim one mismatch when a closer
+  compatible source exists. Select the stable closest same-episode source and
+  report every differing compatibility field.
+- **Matching regressions.** Diagnostic work must not change the indexed lookup,
+  target order, or first-source deduplication.
+- **Interface spread.** Import timing must remain one neutral result behind the
+  existing torrent-client seam, not a logger dependency in every adapter.
+- **Timing ambiguity.** Stage duration is diagnostic data, not a performance
+  guarantee. Skipped stages must be absent instead of reported as zero work.
+
+## steps
+
+1. Add a failing matcher-interface test for missing source, closest mismatch,
+   and duplicate target diagnostics. [done]
+2. Implement diagnostic matching without changing successful selection. [done]
+3. Add failing adapter tests for successful import-stage reports. [done]
+4. Implement neutral stage reports in qBittorrent, Transmission, and Deluge.
+   [done]
+5. Add failing authenticated endpoint log tests for pack reasons and parse
+   stage timing. [done]
+6. Implement structured processor logs and total timing. [done]
+7. Update docs, run focused and full verification, then review the diff on
+   standards and spec axes. [done]
+8. Address review findings, complete the plan, and commit the work. [done]
+
+## decision log
+
+- 2026-08-12: use `EpisodeMatcher.Match` as the diagnostic seam. The release
+  module owns compatibility knowledge; the HTTP module owns log policy.
+- 2026-08-12: diagnose only unmatched targets after the indexed success pass.
+  Do not restore the former quadratic mismatch logging.
+- 2026-08-12: return a neutral import report from `TorrentClient.Import`.
+  Adapters own stage measurement; the processor owns structured output.
+- 2026-08-12: include failed-stage timing. Failure latency is operationally
+  useful, and the existing `ImportError` already identifies the failed stage.
+- 2026-08-12: index client sources by season and episode for diagnostics. This
+  avoids restoring the old full source-target comparison matrix.
+- 2026-08-12: retain a failed exact plan long enough to log every unmatched
+  target before returning the existing failure status.
+- 2026-08-12: use the implementation start commit `60f9b39` as the final review
+  fixed point.
+
+## verification notes
+
+- Production baseline assertion on `hades`:
+  `RED: pack-reason-missing parse-stage-timing-missing`.
+- No production configuration, environment, or credential data was inspected.
+- Focused release, torrent-client, and HTTP package tests pass.
+- Indexed 100-episode benchmark after diagnostics: 16.8 ms median across three
+  10-iteration runs. This is near the prior documented 15.9 ms result.
+- `gofumpt` and `git diff --check` pass.
+- `go test -v ./...` passes. Environment-gated live-client tests were skipped
+  because their external test environments are not configured.
+- `go test -race ./internal/release ./internal/http
+  ./internal/torrentclient` passes.
+- `go vet ./...` passes.
+- `govulncheck ./...` reports no called-code or imported-package
+  vulnerabilities. One required-module vulnerability is not called.
+- Parallel standards and spec reviews found missing failure-path total timing,
+  post-add qBittorrent hash validation, and skipped-stage coverage. All findings
+  were fixed and regression-tested. The minor repeated-switch suggestion was
+  rejected because the explicit five-case mappings are small and clearer than
+  a metadata table.

--- a/docs/product-specs/webhook-contract.md
+++ b/docs/product-specs/webhook-contract.md
@@ -20,19 +20,24 @@ Requests must include the configured API token. Unauthorized requests are reject
 ## Operator Log Contract
 
 - `/api/candidate` logs each release compatibility rejection as a structured
-  event. The event reports the incompatible field, the announced `want` value,
-  the client `got` value, and the client release.
+  event. The event reports the incompatible field, the original announced
+  `want` value, the original client `got` value, and the client release. Fuzzy
+  matching can normalize values for comparison but not for diagnostics.
 - `/api/pack` logs the reusable, unmatched, and total torrent episode counts.
 - Each unmatched torrent episode produces one structured log event. The event
   reports either a missing source episode, a duplicate torrent target, or the
   closest same-episode client source plus every incompatible safety field. Each
   incompatible field reports its torrent `want` and client `got` value.
 - `/api/parse` logs whether it reused or rebuilt the import plan. It also logs
-  destination resolution, hardlink duration, each torrent-client import stage,
-  total client-import duration, and total parse duration.
+  each successful or failed destination-resolution attempt at `INFO`, hardlink
+  duration, each torrent-client import stage, total client-import duration, and
+  total parse duration.
 - Torrent-client stages use the stable names `config`, `add`, `find`,
   `recheck`, and `resume`. A client omits stages that it does not perform.
 - Logs never include configured credentials or request authentication tokens.
+- Expected candidate and pack gate rejections use informational events.
+  Configuration, decoding, client, filesystem, and import failures use error
+  events.
 
 ## Contract Stability Rules
 

--- a/docs/product-specs/webhook-contract.md
+++ b/docs/product-specs/webhook-contract.md
@@ -17,6 +17,23 @@ Requests must include the configured API token. Unauthorized requests are reject
 - `/api/parse` owns the import. It reuses the accepted plan when available and safely rebuilds it on a cache miss. It resolves the client destination, hardlinks matched episodes, and imports through the per-client policy. If achieved smart-mode coverage falls below the threshold, it does not import. Successful hardlinks remain for a safe retry; the service does not perform destructive cleanup.
 - The candidate and pack checks share a short-lived client inventory. A normal candidate, pack, parse sequence performs one inventory scan and one set of candidate file-detail reads.
 
+## Operator Log Contract
+
+- `/api/candidate` logs each release compatibility rejection as a structured
+  event. The event reports the incompatible field, the announced `want` value,
+  the client `got` value, and the client release.
+- `/api/pack` logs the reusable, unmatched, and total torrent episode counts.
+- Each unmatched torrent episode produces one structured log event. The event
+  reports either a missing source episode, a duplicate torrent target, or the
+  closest same-episode client source plus every incompatible safety field. Each
+  incompatible field reports its torrent `want` and client `got` value.
+- `/api/parse` logs whether it reused or rebuilt the import plan. It also logs
+  destination resolution, hardlink duration, each torrent-client import stage,
+  total client-import duration, and total parse duration.
+- Torrent-client stages use the stable names `config`, `add`, `find`,
+  `recheck`, and `resume`. A client omits stages that it does not perform.
+- Logs never include configured credentials or request authentication tokens.
+
 ## Contract Stability Rules
 
 - do not change auth expectations casually

--- a/internal/http/processor_candidate.go
+++ b/internal/http/processor_candidate.go
@@ -98,9 +98,13 @@ func (p *processor) findCandidates(clientName string, clientCfg *domain.Client, 
 		case domain.StatusSuccessfulMatch:
 			candidates = append(candidates, filteredEntry)
 		default:
-			p.log.Info().Msgf("%s: request(%s => %v), client(%s => %v)",
-				compareInfo.StatusCode, requestRls.String(), compareInfo.RejectValueA,
-				filteredEntry.release.String(), compareInfo.RejectValueB)
+			p.log.Info().
+				Str("reason", "compatibility_mismatch").
+				Str("field", candidateMismatchField(compareInfo.StatusCode)).
+				Interface("want", compareInfo.RejectValueA).
+				Interface("got", compareInfo.RejectValueB).
+				Str("client_release", filteredEntry.release.String()).
+				Msg("client release is not compatible")
 		}
 	}
 
@@ -109,6 +113,29 @@ func (p *processor) findCandidates(clientName string, clientCfg *domain.Client, 
 	}
 
 	return candidates, domain.StatusSuccessfulMatch, nil
+}
+
+func candidateMismatchField(statusCode domain.StatusCode) string {
+	switch statusCode {
+	case domain.StatusResolutionMismatch:
+		return "resolution"
+	case domain.StatusSourceMismatch:
+		return "source"
+	case domain.StatusRlsGrpMismatch:
+		return "release_group"
+	case domain.StatusCutMismatch:
+		return "cut"
+	case domain.StatusEditionMismatch:
+		return "edition"
+	case domain.StatusRepackStatusMismatch:
+		return "repack_status"
+	case domain.StatusHdrMismatch:
+		return "hdr"
+	case domain.StatusStreamingServiceMismatch:
+		return "streaming_service"
+	default:
+		return "unknown"
+	}
 }
 
 func (p *processor) getClient(client *domain.Client, clientName string) error {

--- a/internal/http/processor_handlers.go
+++ b/internal/http/processor_handlers.go
@@ -21,10 +21,10 @@ func (p *processor) CandidateSeasonPackHandler(c *gin.Context) {
 
 	statusCode, err := p.candidateSeasonPack()
 	if err != nil {
-		if statusCode.Code() >= http.StatusBadRequest {
-			p.log.Error().Err(err).Msg("error checking season pack candidate")
-		} else {
+		if isExpectedGateRejection(statusCode) {
 			p.log.Info().Err(err).Msg("season pack candidate rejected")
+		} else {
+			p.log.Error().Err(err).Msg("error checking season pack candidate")
 		}
 		abortWithError(c, statusCode, err)
 		return
@@ -44,7 +44,11 @@ func (p *processor) ProcessSeasonPackHandler(c *gin.Context) {
 	statusCode, err := p.processSeasonPack()
 	if err != nil {
 		p.sendNotification(statusCode, "Pack", err)
-		p.log.Error().Err(err).Msg("error processing season pack")
+		if isExpectedGateRejection(statusCode) {
+			p.log.Info().Err(err).Msg("season pack rejected")
+		} else {
+			p.log.Error().Err(err).Msg("error processing season pack")
+		}
 		abortWithError(c, statusCode, err)
 		return
 	}
@@ -52,6 +56,10 @@ func (p *processor) ProcessSeasonPackHandler(c *gin.Context) {
 	p.sendNotification(statusCode, "Pack", nil)
 	p.log.Info().Msg("successfully matched season pack to episodes in client")
 	c.String(statusCode.Code(), statusCode.String())
+}
+
+func isExpectedGateRejection(statusCode domain.StatusCode) bool {
+	return statusCode.Code() < http.StatusBadRequest || statusCode == domain.StatusFailedMatchToTorrentEps
 }
 
 func (p *processor) ParseTorrentHandler(c *gin.Context) {

--- a/internal/http/processor_import.go
+++ b/internal/http/processor_import.go
@@ -87,14 +87,17 @@ func (p *processor) parseTorrent() (statusCode domain.StatusCode, err error) {
 
 	destinationStarted := time.Now()
 	importDestination, err := p.req.Client.ImportDestination()
+	destinationEvent := p.log.Info().
+		Bool("successful", err == nil).
+		Int64("duration_ms", time.Since(destinationStarted).Milliseconds())
 	if err != nil {
+		destinationEvent.Err(err).Msg("import destination resolved")
 		statusCode := torrentclient.ImportStatusCode(err)
 		return statusCode, fmt.Errorf("%s: %w", statusCode, err)
 	}
 	importRoot := importDestination.SavePath()
-	p.log.Debug().
+	destinationEvent.
 		Str("import_root", importRoot).
-		Int64("duration_ms", time.Since(destinationStarted).Milliseconds()).
 		Msg("import destination resolved")
 
 	hardlinkStarted := time.Now()
@@ -109,7 +112,6 @@ func (p *processor) parseTorrent() (statusCode domain.StatusCode, err error) {
 		linkedCount++
 	}
 
-	p.log.Info().Msgf("hardlinked %d/%d episodes from pack", linkedCount, plan.totalEps)
 	p.log.Info().
 		Int("linked_episodes", linkedCount).
 		Int("planned_links", len(plan.links)).

--- a/internal/http/processor_import.go
+++ b/internal/http/processor_import.go
@@ -5,6 +5,7 @@ package http
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/internal/files"
@@ -17,7 +18,18 @@ import (
 
 // parseTorrent is the /api/parse path. It reuses an accepted plan or rebuilds it
 // on a cache miss, hardlinks the planned episodes, then imports the pack.
-func (p *processor) parseTorrent() (domain.StatusCode, error) {
+func (p *processor) parseTorrent() (statusCode domain.StatusCode, err error) {
+	totalStarted := time.Now()
+	defer func() {
+		event := p.log.Info().
+			Bool("successful", err == nil).
+			Int("status_code", int(statusCode)).
+			Int64("total_duration_ms", time.Since(totalStarted).Milliseconds())
+		if err != nil {
+			event = event.Err(err)
+		}
+		event.Msg("season pack import completed")
+	}()
 	clientName := p.getClientName()
 	snapshot := p.cfg.Snapshot()
 
@@ -48,13 +60,22 @@ func (p *processor) parseTorrent() (domain.StatusCode, error) {
 		return domain.StatusParseTorrentInfoError, fmt.Errorf("%s: %w", domain.StatusParseTorrentInfoError, err)
 	}
 
+	planStarted := time.Now()
+	planSource := "cache"
 	plan, ok := p.loadImportPlan(clientName, *clientCfg, snapshot.FuzzyMatching, hashes)
 	if !ok {
-		var statusCode domain.StatusCode
-		plan, statusCode, err = p.buildImportPlan(clientName, clientCfg, snapshot)
-		if err != nil {
-			return statusCode, err
-		}
+		planSource = "rebuilt"
+		var planStatusCode domain.StatusCode
+		plan, planStatusCode, err = p.buildImportPlan(clientName, clientCfg, snapshot)
+		statusCode = planStatusCode
+	}
+	p.log.Info().
+		Str("plan_source", planSource).
+		Bool("successful", err == nil).
+		Int64("duration_ms", time.Since(planStarted).Milliseconds()).
+		Msg("import plan resolved")
+	if err != nil {
+		return statusCode, err
 	}
 
 	if snapshot.SmartMode {
@@ -64,14 +85,19 @@ func (p *processor) parseTorrent() (domain.StatusCode, error) {
 		}
 	}
 
+	destinationStarted := time.Now()
 	importDestination, err := p.req.Client.ImportDestination()
 	if err != nil {
 		statusCode := torrentclient.ImportStatusCode(err)
 		return statusCode, fmt.Errorf("%s: %w", statusCode, err)
 	}
 	importRoot := importDestination.SavePath()
-	p.log.Debug().Msgf("resolved import root: %s", importRoot)
+	p.log.Debug().
+		Str("import_root", importRoot).
+		Int64("duration_ms", time.Since(destinationStarted).Milliseconds()).
+		Msg("import destination resolved")
 
+	hardlinkStarted := time.Now()
 	linkedCount := 0
 	for _, link := range plan.links {
 		targetEpPath := importDestination.TargetPath(plan.packName, link.torrentEpPath)
@@ -84,6 +110,12 @@ func (p *processor) parseTorrent() (domain.StatusCode, error) {
 	}
 
 	p.log.Info().Msgf("hardlinked %d/%d episodes from pack", linkedCount, plan.totalEps)
+	p.log.Info().
+		Int("linked_episodes", linkedCount).
+		Int("planned_links", len(plan.links)).
+		Int("total_episodes", plan.totalEps).
+		Int64("duration_ms", time.Since(hardlinkStarted).Milliseconds()).
+		Msg("hardlink stage completed")
 	if linkedCount == 0 {
 		return domain.StatusFailedHardlink, domain.StatusFailedHardlink.Error()
 	}
@@ -94,13 +126,25 @@ func (p *processor) parseTorrent() (domain.StatusCode, error) {
 		}
 	}
 
-	if err := p.req.Client.Import(torrentclient.ImportRequest{
+	clientImportStarted := time.Now()
+	importReport, err := p.req.Client.Import(torrentclient.ImportRequest{
 		TorrentBytes: plan.torrentBytes,
 		SavePath:     importRoot,
 		LegacyHash:   plan.hashes.Legacy,
 		V2Hash:       plan.hashes.V2,
 		HasV1:        plan.hashes.HasV1,
-	}); err != nil {
+	})
+	for _, stage := range importReport.Stages {
+		p.log.Info().
+			Str("stage", stage.Stage.String()).
+			Int64("duration_ms", stage.Duration.Milliseconds()).
+			Msg("torrent client import stage finished")
+	}
+	p.log.Info().
+		Bool("successful", err == nil).
+		Int64("duration_ms", time.Since(clientImportStarted).Milliseconds()).
+		Msg("torrent client import completed")
+	if err != nil {
 		statusCode := torrentclient.ImportStatusCode(err)
 		return statusCode, fmt.Errorf("%s: %w", statusCode, err)
 	}

--- a/internal/http/processor_integration_test.go
+++ b/internal/http/processor_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -226,7 +227,10 @@ func TestAuthenticatedCandidateLogsStructuredCompatibilityMismatch(t *testing.T)
 
 	var output bytes.Buffer
 	f := newProcessorHTTPFixtureWithLogger(t, 2, 2, 0.5, newCapturedLogger(&output))
-	f.mock.torrents[0].Name = "Lifecycle.S01E01.720p.WEB-DL.H.264-RlsGrp"
+	f.mock.torrents[0].Name = "Lifecycle.S01E01.1080p.BluRay.H.264-RlsGrp"
+	cfg := f.config.Snapshot()
+	cfg.FuzzyMatching.SimplifyWebCompare = true
+	f.config.Store(cfg)
 
 	response := f.postJSON(t, "/api/candidate", map[string]any{
 		"name":       f.releaseName,
@@ -237,10 +241,10 @@ func TestAuthenticatedCandidateLogsStructuredCompatibilityMismatch(t *testing.T)
 	logs := decodeCapturedLogs(t, &output)
 	mismatch := requireCapturedLog(t, logs, "client release is not compatible")
 	require.Equal(t, "compatibility_mismatch", mismatch["reason"])
-	require.Equal(t, "resolution", mismatch["field"])
-	require.Equal(t, "1080p", mismatch["want"])
-	require.Equal(t, "720p", mismatch["got"])
-	require.Equal(t, "Lifecycle.S01E01.720p.WEB-DL.H.264-RlsGrp", mismatch["client_release"])
+	require.Equal(t, "source", mismatch["field"])
+	require.Equal(t, "WEB-DL", mismatch["want"])
+	require.Equal(t, "BluRay", mismatch["got"])
+	require.Equal(t, "Lifecycle.S01E01.1080p.BluRay.H.264-RlsGrp", mismatch["client_release"])
 }
 
 func TestAuthenticatedPackLogsUnmatchedTorrentEpisode(t *testing.T) {
@@ -287,6 +291,26 @@ func TestAuthenticatedPackLogsReasonWhenNoEpisodeIsReusable(t *testing.T) {
 		"want":  float64(1),
 		"got":   float64(2),
 	}}, unmatched["mismatches"])
+	rejection := requireCapturedLog(t, logs, "season pack rejected")
+	require.Equal(t, "info", rejection["level"])
+	require.Equal(t, "could not match episodes to files in pack", rejection["error"])
+}
+
+func TestAuthenticatedPackLogsBelowThresholdAsExpectedRejection(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 2, 1, 0.75, newCapturedLogger(&output))
+
+	response := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusBelowThreshold.Code(), response.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	rejection := requireCapturedLog(t, logs, "season pack rejected")
+	require.Equal(t, "info", rejection["level"])
+	require.Equal(t, "number of matches below threshold", rejection["error"])
 }
 
 func TestAuthenticatedParseLogsClientImportStageTiming(t *testing.T) {
@@ -316,9 +340,18 @@ func TestAuthenticatedParseLogsClientImportStageTiming(t *testing.T) {
 	require.Equal(t, "cache", plan["plan_source"])
 	require.Contains(t, plan, "duration_ms")
 
+	destination := requireCapturedLog(t, logs, "import destination resolved")
+	require.Equal(t, "info", destination["level"])
+	require.Equal(t, true, destination["successful"])
+	require.Contains(t, destination, "duration_ms")
+
 	hardlinks := requireCapturedLog(t, logs, "hardlink stage completed")
 	require.Equal(t, float64(2), hardlinks["linked_episodes"])
 	require.Contains(t, hardlinks, "duration_ms")
+	for _, event := range logs {
+		message, _ := event["message"].(string)
+		require.False(t, strings.HasPrefix(message, "hardlinked "), "legacy hardlink summary must be absent")
+	}
 
 	recheck := requireCapturedLogField(t, logs, "torrent client import stage finished", "stage", "recheck")
 	require.Equal(t, float64(35_000), recheck["duration_ms"])
@@ -355,6 +388,33 @@ func TestAuthenticatedParseLogsTotalTimingOnImportFailure(t *testing.T) {
 	require.Equal(t, false, completed["successful"])
 	require.Equal(t, float64(domain.StatusAddTorrentError), completed["status_code"])
 	require.Contains(t, completed, "total_duration_ms")
+}
+
+func TestAuthenticatedParseLogsFailedDestinationResolutionTiming(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 1, 1, 0, newCapturedLogger(&output))
+
+	pack := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), pack.Code)
+	f.mock.importRootErr = &torrentclient.ImportError{
+		Stage: torrentclient.ImportStageConfig,
+		Err:   errors.New("destination unavailable"),
+	}
+	output.Reset()
+
+	parse := f.postJSON(t, "/api/parse", f.packPayload())
+	require.Equal(t, domain.StatusImportConfigError.Code(), parse.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	destination := requireCapturedLog(t, logs, "import destination resolved")
+	require.Equal(t, "info", destination["level"])
+	require.Equal(t, false, destination["successful"])
+	require.Contains(t, destination, "duration_ms")
+	require.Equal(t, "destination unavailable", destination["error"])
 }
 
 func TestAuthenticatedParseLogsFailedPlanRebuildTiming(t *testing.T) {

--- a/internal/http/processor_integration_test.go
+++ b/internal/http/processor_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nuxencs/seasonpackarr/internal/torrents"
 
 	"github.com/puzpuzpuz/xsync/v3"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,6 +65,16 @@ type processorHTTPFixture struct {
 }
 
 func newProcessorHTTPFixture(t *testing.T, torrentEpisodes, clientEpisodes int, threshold float32) processorHTTPFixture {
+	return newProcessorHTTPFixtureWithLogger(t, torrentEpisodes, clientEpisodes, threshold,
+		logger.New(&domain.Config{LogLevel: "ERROR", Version: "test"}))
+}
+
+func newProcessorHTTPFixtureWithLogger(
+	t *testing.T,
+	torrentEpisodes, clientEpisodes int,
+	threshold float32,
+	log logger.Logger,
+) processorHTTPFixture {
 	t.Helper()
 	resetProcessorGlobals()
 
@@ -110,7 +121,7 @@ func newProcessorHTTPFixture(t *testing.T, torrentEpisodes, clientEpisodes int, 
 	clientMap.Store("default", cachedTorrentClient{config: cloneClientConfig(*clientCfg), client: mock})
 
 	server := NewServer(
-		logger.New(&domain.Config{LogLevel: "ERROR", Version: "test"}),
+		log,
 		cfg,
 		noopNotificationSender{},
 	)
@@ -123,6 +134,62 @@ func newProcessorHTTPFixture(t *testing.T, torrentEpisodes, clientEpisodes int, 
 		sourceDir:   sourceDir,
 		importDir:   importDir,
 	}
+}
+
+type capturedLogger struct {
+	log zerolog.Logger
+}
+
+func newCapturedLogger(output *bytes.Buffer) logger.Logger {
+	return &capturedLogger{log: zerolog.New(output)}
+}
+
+func (l *capturedLogger) Log() *zerolog.Event          { return l.log.Log() }
+func (l *capturedLogger) Fatal() *zerolog.Event        { return l.log.Error() }
+func (l *capturedLogger) Err(err error) *zerolog.Event { return l.log.Err(err) }
+func (l *capturedLogger) Error() *zerolog.Event        { return l.log.Error() }
+func (l *capturedLogger) Warn() *zerolog.Event         { return l.log.Warn() }
+func (l *capturedLogger) Info() *zerolog.Event         { return l.log.Info() }
+func (l *capturedLogger) Trace() *zerolog.Event        { return l.log.Trace() }
+func (l *capturedLogger) Debug() *zerolog.Event        { return l.log.Debug() }
+func (l *capturedLogger) With() zerolog.Context        { return l.log.With() }
+func (l *capturedLogger) SetLogLevel(string)           {}
+
+func decodeCapturedLogs(t *testing.T, output *bytes.Buffer) []map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(output.Bytes()), []byte("\n"))
+	logs := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var event map[string]any
+		require.NoError(t, json.Unmarshal(line, &event))
+		logs = append(logs, event)
+	}
+	return logs
+}
+
+func requireCapturedLog(t *testing.T, logs []map[string]any, message string) map[string]any {
+	t.Helper()
+	for _, event := range logs {
+		if event["message"] == message {
+			return event
+		}
+	}
+	t.Fatalf("missing log message %q in %#v", message, logs)
+	return nil
+}
+
+func requireCapturedLogField(t *testing.T, logs []map[string]any, message, field string, value any) map[string]any {
+	t.Helper()
+	for _, event := range logs {
+		if event["message"] == message && event[field] == value {
+			return event
+		}
+	}
+	t.Fatalf("missing log message %q with %s=%v in %#v", message, field, value, logs)
+	return nil
 }
 
 func (f processorHTTPFixture) postJSON(t *testing.T, path string, payload any) *httptest.ResponseRecorder {
@@ -150,6 +217,167 @@ func (f processorHTTPFixture) packPayload() map[string]any {
 		"clientname": "default",
 		"torrent":    base64.StdEncoding.EncodeToString(f.torrent),
 	}
+}
+
+func TestAuthenticatedCandidateLogsStructuredCompatibilityMismatch(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 2, 2, 0.5, newCapturedLogger(&output))
+	f.mock.torrents[0].Name = "Lifecycle.S01E01.720p.WEB-DL.H.264-RlsGrp"
+
+	response := f.postJSON(t, "/api/candidate", map[string]any{
+		"name":       f.releaseName,
+		"clientname": "default",
+	})
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), response.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	mismatch := requireCapturedLog(t, logs, "client release is not compatible")
+	require.Equal(t, "compatibility_mismatch", mismatch["reason"])
+	require.Equal(t, "resolution", mismatch["field"])
+	require.Equal(t, "1080p", mismatch["want"])
+	require.Equal(t, "720p", mismatch["got"])
+	require.Equal(t, "Lifecycle.S01E01.720p.WEB-DL.H.264-RlsGrp", mismatch["client_release"])
+}
+
+func TestAuthenticatedPackLogsUnmatchedTorrentEpisode(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 2, 1, 0.5, newCapturedLogger(&output))
+
+	response := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), response.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	unmatched := requireCapturedLog(t, logs, "torrent episode is not reusable")
+	require.Equal(t, "Lifecycle.S01E02.1080p.WEB-DL.H.264-RlsGrp.mkv", filepath.Base(unmatched["torrent_path"].(string)))
+	require.Equal(t, "source_episode_not_found", unmatched["reason"])
+
+	summary := requireCapturedLog(t, logs, "season pack import plan built")
+	require.Equal(t, float64(1), summary["reusable_episodes"])
+	require.Equal(t, float64(2), summary["total_episodes"])
+	require.Equal(t, float64(1), summary["unmatched_episodes"])
+	require.Equal(t, float64(50), summary["coverage_percent"])
+	require.Equal(t, float64(50), summary["threshold_percent"])
+}
+
+func TestAuthenticatedPackLogsReasonWhenNoEpisodeIsReusable(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 1, 1, 0, newCapturedLogger(&output))
+	f.mock.filesByHash["ep1"][0].Size = 2
+
+	response := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusFailedMatchToTorrentEps.Code(), response.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	unmatched := requireCapturedLog(t, logs, "torrent episode is not reusable")
+	require.Equal(t, "compatibility_mismatch", unmatched["reason"])
+	require.Equal(t, []any{map[string]any{
+		"field": "size",
+		"want":  float64(1),
+		"got":   float64(2),
+	}}, unmatched["mismatches"])
+}
+
+func TestAuthenticatedParseLogsClientImportStageTiming(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 2, 2, 0.75, newCapturedLogger(&output))
+	f.mock.importReport = torrentclient.ImportReport{Stages: []torrentclient.ImportStageReport{
+		{Stage: torrentclient.ImportStageConfig, Duration: 2 * time.Millisecond},
+		{Stage: torrentclient.ImportStageAdd, Duration: 12 * time.Millisecond},
+		{Stage: torrentclient.ImportStageFind, Duration: 800 * time.Millisecond},
+		{Stage: torrentclient.ImportStageRecheck, Duration: 35 * time.Second},
+		{Stage: torrentclient.ImportStageResume, Duration: 3 * time.Millisecond},
+	}}
+
+	pack := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), pack.Code)
+	output.Reset()
+
+	parse := f.postJSON(t, "/api/parse", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulHardlink.Code(), parse.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	plan := requireCapturedLog(t, logs, "import plan resolved")
+	require.Equal(t, "cache", plan["plan_source"])
+	require.Contains(t, plan, "duration_ms")
+
+	hardlinks := requireCapturedLog(t, logs, "hardlink stage completed")
+	require.Equal(t, float64(2), hardlinks["linked_episodes"])
+	require.Contains(t, hardlinks, "duration_ms")
+
+	recheck := requireCapturedLogField(t, logs, "torrent client import stage finished", "stage", "recheck")
+	require.Equal(t, float64(35_000), recheck["duration_ms"])
+
+	completed := requireCapturedLog(t, logs, "season pack import completed")
+	require.Contains(t, completed, "total_duration_ms")
+}
+
+func TestAuthenticatedParseLogsTotalTimingOnImportFailure(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 1, 1, 0, newCapturedLogger(&output))
+	f.mock.importReport = torrentclient.ImportReport{Stages: []torrentclient.ImportStageReport{
+		{Stage: torrentclient.ImportStageConfig, Duration: time.Millisecond},
+		{Stage: torrentclient.ImportStageAdd, Duration: 12 * time.Millisecond},
+	}}
+	f.mock.importErr = &torrentclient.ImportError{
+		Stage: torrentclient.ImportStageAdd,
+		Err:   errors.New("client rejected torrent"),
+	}
+
+	pack := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), pack.Code)
+	output.Reset()
+
+	parse := f.postJSON(t, "/api/parse", f.packPayload())
+	require.Equal(t, domain.StatusAddTorrentError.Code(), parse.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	completed := requireCapturedLog(t, logs, "season pack import completed")
+	require.Equal(t, false, completed["successful"])
+	require.Equal(t, float64(domain.StatusAddTorrentError), completed["status_code"])
+	require.Contains(t, completed, "total_duration_ms")
+}
+
+func TestAuthenticatedParseLogsFailedPlanRebuildTiming(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 1, 1, 0, newCapturedLogger(&output))
+	f.mock.filesByHash["ep1"][0].Size = 2
+
+	parse := f.postJSON(t, "/api/parse", f.packPayload())
+	require.Equal(t, domain.StatusFailedMatchToTorrentEps.Code(), parse.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	plan := requireCapturedLog(t, logs, "import plan resolved")
+	require.Equal(t, "rebuilt", plan["plan_source"])
+	require.Equal(t, false, plan["successful"])
+	require.Contains(t, plan, "duration_ms")
+
+	completed := requireCapturedLog(t, logs, "season pack import completed")
+	require.Equal(t, false, completed["successful"])
+	require.Contains(t, completed, "total_duration_ms")
 }
 
 func TestAuthenticatedHTTPLifecycleReusesAcceptedPlan(t *testing.T) {

--- a/internal/http/processor_plan.go
+++ b/internal/http/processor_plan.go
@@ -29,6 +29,7 @@ type importPlan struct {
 	hashes       torrents.Hashes
 	packName     string
 	links        []plannedLink
+	unmatched    []release.EpisodeUnmatched
 	totalEps     int
 }
 
@@ -67,13 +68,15 @@ func (p *processor) processSeasonPack() (domain.StatusCode, error) {
 	p.log.Info().Msgf("using %s client", clientName)
 
 	plan, statusCode, err := p.buildImportPlan(clientName, clientCfg, snapshot)
+	coverage := float32(0)
+	if plan.totalEps > 0 {
+		coverage = p.logImportPlan(plan, snapshot)
+	}
 	if err != nil {
 		return statusCode, err
 	}
 
 	if snapshot.SmartMode {
-		coverage := release.PercentOfTotalEpisodes(plan.totalEps, len(plan.links))
-		p.log.Info().Msgf("found %d/%d (%.2f%%) reusable episodes in announced torrent", len(plan.links), plan.totalEps, coverage*100)
 		if coverage < snapshot.SmartModeThreshold {
 			return domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
 		}
@@ -82,6 +85,41 @@ func (p *processor) processSeasonPack() (domain.StatusCode, error) {
 	p.storeImportPlan(clientName, *clientCfg, snapshot.FuzzyMatching, plan)
 
 	return domain.StatusSuccessfulMatch, nil
+}
+
+func (p *processor) logImportPlan(plan importPlan, cfg domain.Config) float32 {
+	for _, unmatched := range plan.unmatched {
+		event := p.log.Info().
+			Str("torrent_path", unmatched.TorrentPath).
+			Str("reason", string(unmatched.Reason))
+		if unmatched.ClosestClientPath != "" {
+			event = event.Str("closest_client_path", unmatched.ClosestClientPath)
+		}
+		if len(unmatched.Mismatches) > 0 {
+			mismatches := make([]map[string]any, len(unmatched.Mismatches))
+			for index, mismatch := range unmatched.Mismatches {
+				mismatches[index] = map[string]any{
+					"field": string(mismatch.Field),
+					"want":  mismatch.Want,
+					"got":   mismatch.Got,
+				}
+			}
+			event = event.Interface("mismatches", mismatches)
+		}
+		event.Msg("torrent episode is not reusable")
+	}
+
+	coverage := release.PercentOfTotalEpisodes(plan.totalEps, len(plan.links))
+	summary := p.log.Info().
+		Int("reusable_episodes", len(plan.links)).
+		Int("total_episodes", plan.totalEps).
+		Int("unmatched_episodes", len(plan.unmatched)).
+		Float32("coverage_percent", coverage*100)
+	if cfg.SmartMode {
+		summary = summary.Float32("threshold_percent", cfg.SmartModeThreshold*100)
+	}
+	summary.Msg("season pack import plan built")
+	return coverage
 }
 
 func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client, cfg domain.Config) (importPlan, domain.StatusCode, error) {
@@ -124,26 +162,28 @@ func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client,
 	}
 
 	matcher := release.NewEpisodeMatcher(eligibleEps)
-	matches := matcher.Match(p.getEpisodeFiles(candidates))
-	if len(matches) == 0 {
-		return importPlan{}, domain.StatusFailedMatchToTorrentEps, domain.StatusFailedMatchToTorrentEps.Error()
-	}
+	matchResult := matcher.Match(p.getEpisodeFiles(candidates))
 
-	links := make([]plannedLink, 0, len(matches))
-	for _, match := range matches {
+	links := make([]plannedLink, 0, len(matchResult.Matches))
+	for _, match := range matchResult.Matches {
 		links = append(links, plannedLink{
 			clientEpPath:  match.ClientPath,
 			torrentEpPath: match.TorrentPath,
 		})
 	}
 
-	return importPlan{
+	plan := importPlan{
 		torrentBytes: torrentBytes,
 		hashes:       hashes,
 		packName:     torrentInfo.BestName(),
 		links:        links,
+		unmatched:    matchResult.Unmatched,
 		totalEps:     len(eligibleEps),
-	}, domain.StatusSuccessfulMatch, nil
+	}
+	if len(matchResult.Matches) == 0 {
+		return plan, domain.StatusFailedMatchToTorrentEps, domain.StatusFailedMatchToTorrentEps.Error()
+	}
+	return plan, domain.StatusSuccessfulMatch, nil
 }
 
 func (p *processor) getEpisodeFiles(candidates []entry) []release.EpisodeFile {

--- a/internal/http/processor_test.go
+++ b/internal/http/processor_test.go
@@ -46,6 +46,7 @@ type mockTorrentClient struct {
 	importRootErr error
 	flatImport    bool
 	importErr     error
+	importReport  torrentclient.ImportReport
 	importCalled  bool
 	importCalls   int
 	importReq     torrentclient.ImportRequest
@@ -118,6 +119,24 @@ func TestCandidateSeasonPackUsesTorrentSummariesOnly(t *testing.T) {
 	require.Equal(t, domain.StatusSuccessfulMatch, statusCode)
 	require.Equal(t, 1, mock.torrentCalls)
 	require.Zero(t, mock.fileCalls, "candidate evaluation must not request torrent file details")
+}
+
+func TestCandidateMismatchField(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[domain.StatusCode]string{
+		domain.StatusResolutionMismatch:       "resolution",
+		domain.StatusSourceMismatch:           "source",
+		domain.StatusRlsGrpMismatch:           "release_group",
+		domain.StatusCutMismatch:              "cut",
+		domain.StatusEditionMismatch:          "edition",
+		domain.StatusRepackStatusMismatch:     "repack_status",
+		domain.StatusHdrMismatch:              "hdr",
+		domain.StatusStreamingServiceMismatch: "streaming_service",
+	}
+	for statusCode, want := range testCases {
+		require.Equal(t, want, candidateMismatchField(statusCode))
+	}
 }
 
 func TestCandidateEndpointReturnsSuccessfulMatchWithoutFileReads(t *testing.T) {
@@ -369,11 +388,11 @@ func (m *mockTorrentClient) ImportDestination() (torrentclient.ImportDestination
 	return torrentclient.NewRootedImportDestination(m.importRoot), nil
 }
 
-func (m *mockTorrentClient) Import(req torrentclient.ImportRequest) error {
+func (m *mockTorrentClient) Import(req torrentclient.ImportRequest) (torrentclient.ImportReport, error) {
 	m.importCalled = true
 	m.importCalls++
 	m.importReq = req
-	return m.importErr
+	return m.importReport, m.importErr
 }
 
 func newTestProcessor(client torrentclient.TorrentClient) *processor {

--- a/internal/release/episode.go
+++ b/internal/release/episode.go
@@ -19,6 +19,11 @@ type episodeMatchKey struct {
 	group      string
 }
 
+type episodeIdentityKey struct {
+	series  int
+	episode int
+}
+
 // EpisodeFile is a valid parsed episode video. Its parser details stay private
 // so callers cannot construct a partially normalized matching value.
 type EpisodeFile struct {
@@ -70,6 +75,49 @@ type EpisodeMatch struct {
 	TorrentPath string
 }
 
+type EpisodeUnmatchedReason string
+
+const (
+	EpisodeUnmatchedSourceMissing         EpisodeUnmatchedReason = "source_episode_not_found"
+	EpisodeUnmatchedCompatibilityMismatch EpisodeUnmatchedReason = "compatibility_mismatch"
+	EpisodeUnmatchedDuplicateTarget       EpisodeUnmatchedReason = "duplicate_torrent_target"
+)
+
+type EpisodeMismatchField string
+
+const (
+	EpisodeMismatchSize         EpisodeMismatchField = "size"
+	EpisodeMismatchContainer    EpisodeMismatchField = "container"
+	EpisodeMismatchResolution   EpisodeMismatchField = "resolution"
+	EpisodeMismatchReleaseGroup EpisodeMismatchField = "release_group"
+)
+
+const episodeCompatibilityFieldCount = 4
+
+// EpisodeMismatch reports one incompatible value. Want is the announced
+// torrent target requirement. Got is the closest client source value.
+type EpisodeMismatch struct {
+	Field EpisodeMismatchField
+	Want  any
+	Got   any
+}
+
+// EpisodeUnmatched explains why one valid torrent target cannot reuse a client
+// episode.
+type EpisodeUnmatched struct {
+	TorrentPath       string
+	ClosestClientPath string
+	Reason            EpisodeUnmatchedReason
+	Mismatches        []EpisodeMismatch
+}
+
+// EpisodeMatchResult contains the reusable links and diagnostics for every
+// valid torrent target that did not receive one.
+type EpisodeMatchResult struct {
+	Matches   []EpisodeMatch
+	Unmatched []EpisodeUnmatched
+}
+
 // EpisodeMatcher indexes valid torrent targets once. Duplicate target keys keep
 // the first target, matching the former stable nested-scan behavior.
 type EpisodeMatcher struct {
@@ -96,7 +144,7 @@ func (m EpisodeMatcher) Len() int {
 
 // Match returns at most one client source per torrent target. Results follow
 // torrent target order, independent of client inventory order.
-func (m EpisodeMatcher) Match(sources []EpisodeFile) []EpisodeMatch {
+func (m EpisodeMatcher) Match(sources []EpisodeFile) EpisodeMatchResult {
 	clientPathByTarget := make(map[int]string, min(len(sources), len(m.targets)))
 	for _, source := range sources {
 		targetIndex, ok := m.firstTargetByKey[source.key]
@@ -109,9 +157,27 @@ func (m EpisodeMatcher) Match(sources []EpisodeFile) []EpisodeMatch {
 	}
 
 	matches := make([]EpisodeMatch, 0, len(clientPathByTarget))
+	unmatched := make([]EpisodeUnmatched, 0, len(m.targets)-len(clientPathByTarget))
+	var sourcesByIdentity map[episodeIdentityKey][]EpisodeFile
+	if len(clientPathByTarget) < len(m.targets) {
+		sourcesByIdentity = make(map[episodeIdentityKey][]EpisodeFile, len(sources))
+		for _, source := range sources {
+			identity := episodeIdentityKey{series: source.key.series, episode: source.key.episode}
+			sourcesByIdentity[identity] = append(sourcesByIdentity[identity], source)
+		}
+	}
 	for targetIndex, target := range m.targets {
 		clientPath, ok := clientPathByTarget[targetIndex]
 		if !ok {
+			if firstTarget := m.firstTargetByKey[target.key]; firstTarget != targetIndex {
+				unmatched = append(unmatched, EpisodeUnmatched{
+					TorrentPath: target.path,
+					Reason:      EpisodeUnmatchedDuplicateTarget,
+				})
+				continue
+			}
+			identity := episodeIdentityKey{series: target.key.series, episode: target.key.episode}
+			unmatched = append(unmatched, diagnoseUnmatchedEpisode(target, sourcesByIdentity[identity]))
 			continue
 		}
 		matches = append(matches, EpisodeMatch{
@@ -119,5 +185,57 @@ func (m EpisodeMatcher) Match(sources []EpisodeFile) []EpisodeMatch {
 			TorrentPath: target.path,
 		})
 	}
-	return matches
+	return EpisodeMatchResult{Matches: matches, Unmatched: unmatched}
+}
+
+func diagnoseUnmatchedEpisode(target EpisodeFile, sources []EpisodeFile) EpisodeUnmatched {
+	diagnostic := EpisodeUnmatched{
+		TorrentPath: target.path,
+		Reason:      EpisodeUnmatchedSourceMissing,
+	}
+	bestFieldCount := episodeCompatibilityFieldCount + 1
+	for _, source := range sources {
+		mismatches := compatibilityMismatches(source.key, target.key)
+		if len(mismatches) == 0 || len(mismatches) >= bestFieldCount {
+			continue
+		}
+		bestFieldCount = len(mismatches)
+		diagnostic.ClosestClientPath = source.path
+		diagnostic.Reason = EpisodeUnmatchedCompatibilityMismatch
+		diagnostic.Mismatches = mismatches
+	}
+	return diagnostic
+}
+
+func compatibilityMismatches(source, target episodeMatchKey) []EpisodeMismatch {
+	mismatches := make([]EpisodeMismatch, 0, episodeCompatibilityFieldCount)
+	if source.size != target.size {
+		mismatches = append(mismatches, EpisodeMismatch{
+			Field: EpisodeMismatchSize,
+			Want:  target.size,
+			Got:   source.size,
+		})
+	}
+	if source.ext != target.ext {
+		mismatches = append(mismatches, EpisodeMismatch{
+			Field: EpisodeMismatchContainer,
+			Want:  target.ext,
+			Got:   source.ext,
+		})
+	}
+	if source.resolution != target.resolution {
+		mismatches = append(mismatches, EpisodeMismatch{
+			Field: EpisodeMismatchResolution,
+			Want:  target.resolution,
+			Got:   source.resolution,
+		})
+	}
+	if source.group != target.group {
+		mismatches = append(mismatches, EpisodeMismatch{
+			Field: EpisodeMismatchReleaseGroup,
+			Want:  target.group,
+			Got:   source.group,
+		})
+	}
+	return mismatches
 }

--- a/internal/release/episode_test.go
+++ b/internal/release/episode_test.go
@@ -24,11 +24,11 @@ func TestEpisodeMatcherChecksEveryCompatibilityField(t *testing.T) {
 		requireEpisodeFile(t, "/client/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
 	}
 
-	matches := NewEpisodeMatcher([]EpisodeFile{target}).Match(sources)
+	result := NewEpisodeMatcher([]EpisodeFile{target}).Match(sources)
 	require.Equal(t, []EpisodeMatch{{
 		ClientPath:  "/client/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
 		TorrentPath: "Show.S01/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
-	}}, matches)
+	}}, result.Matches)
 }
 
 func TestEpisodeMatcherPreservesTargetOrderAndDeduplicatesSources(t *testing.T) {
@@ -44,7 +44,7 @@ func TestEpisodeMatcherPreservesTargetOrderAndDeduplicatesSources(t *testing.T) 
 		requireEpisodeFile(t, "/second/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
 	}
 
-	matches := NewEpisodeMatcher(targets).Match(sources)
+	result := NewEpisodeMatcher(targets).Match(sources)
 	require.Equal(t, []EpisodeMatch{
 		{
 			ClientPath:  "/first/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
@@ -54,7 +54,7 @@ func TestEpisodeMatcherPreservesTargetOrderAndDeduplicatesSources(t *testing.T) 
 			ClientPath:  "/client/Show.S01E02.1080p.WEB-DL-GROUP.mkv",
 			TorrentPath: "Show.S01/Show.S01E02.1080p.WEB-DL-GROUP.mkv",
 		},
-	}, matches)
+	}, result.Matches)
 }
 
 func TestEpisodeMatcherKeepsFirstDuplicateTarget(t *testing.T) {
@@ -69,11 +69,70 @@ func TestEpisodeMatcherKeepsFirstDuplicateTarget(t *testing.T) {
 		requireEpisodeFile(t, "/client-b/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
 	}
 
-	matches := NewEpisodeMatcher(targets).Match(sources)
+	result := NewEpisodeMatcher(targets).Match(sources)
 	require.Equal(t, []EpisodeMatch{{
 		ClientPath:  "/client-a/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
 		TorrentPath: "first/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
-	}}, matches)
+	}}, result.Matches)
+	require.Equal(t, []EpisodeUnmatched{{
+		TorrentPath: "second/Show.S01E01.1080p.WEB-DL-GROUP.mkv",
+		Reason:      EpisodeUnmatchedDuplicateTarget,
+	}}, result.Unmatched)
+}
+
+func TestEpisodeMatcherReportsTargetWithoutSourceEpisode(t *testing.T) {
+	t.Parallel()
+
+	targets := []EpisodeFile{
+		requireEpisodeFile(t, "Show.S01/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+		requireEpisodeFile(t, "Show.S01/Show.S01E02.1080p.WEB-DL-GROUP.mkv", 200),
+	}
+	sources := []EpisodeFile{
+		requireEpisodeFile(t, "/client/Show.S01E01.1080p.WEB-DL-GROUP.mkv", 100),
+	}
+
+	result := NewEpisodeMatcher(targets).Match(sources)
+	require.Equal(t, []EpisodeUnmatched{{
+		TorrentPath: "Show.S01/Show.S01E02.1080p.WEB-DL-GROUP.mkv",
+		Reason:      EpisodeUnmatchedSourceMissing,
+	}}, result.Unmatched)
+}
+
+func TestEpisodeMatcherReportsClosestCompatibilityMismatch(t *testing.T) {
+	t.Parallel()
+
+	target := requireEpisodeFile(t, "Show.S01/Show.S01E05.1080p.WEB-DL-GROUP.mkv", 100)
+	sources := []EpisodeFile{
+		requireEpisodeFile(t, "/client/Show.S01E05.1080p.WEB-DL-GROUP.mp4", 101),
+		requireEpisodeFile(t, "/client/Show.S01E05.1080p.WEB-DL-OTHER.mkv", 100),
+	}
+
+	result := NewEpisodeMatcher([]EpisodeFile{target}).Match(sources)
+	require.Equal(t, []EpisodeUnmatched{{
+		TorrentPath:       "Show.S01/Show.S01E05.1080p.WEB-DL-GROUP.mkv",
+		ClosestClientPath: "/client/Show.S01E05.1080p.WEB-DL-OTHER.mkv",
+		Reason:            EpisodeUnmatchedCompatibilityMismatch,
+		Mismatches: []EpisodeMismatch{{
+			Field: EpisodeMismatchReleaseGroup,
+			Want:  "group",
+			Got:   "other",
+		}},
+	}}, result.Unmatched)
+}
+
+func TestEpisodeMatcherReportsWantAndGotForEveryCompatibilityMismatch(t *testing.T) {
+	t.Parallel()
+
+	target := requireEpisodeFile(t, "Show.S01/Show.S01E05.1080p.WEB-DL-GROUP.mkv", 100)
+	source := requireEpisodeFile(t, "/client/Show.S01E05.2160p.WEB-DL-OTHER.mp4", 101)
+
+	result := NewEpisodeMatcher([]EpisodeFile{target}).Match([]EpisodeFile{source})
+	require.Equal(t, []EpisodeMismatch{
+		{Field: EpisodeMismatchSize, Want: int64(100), Got: int64(101)},
+		{Field: EpisodeMismatchContainer, Want: "mkv", Got: "mp4"},
+		{Field: EpisodeMismatchResolution, Want: "1080p", Got: "2160p"},
+		{Field: EpisodeMismatchReleaseGroup, Want: "group", Got: "other"},
+	}, result.Unmatched[0].Mismatches)
 }
 
 func BenchmarkEpisodeMatching(b *testing.B) {

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -5,6 +5,7 @@ package release
 
 import (
 	"path/filepath"
+	stdslices "slices"
 	"strings"
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
@@ -32,6 +33,8 @@ func compare(requestRls, clientRls rls.Release, fuzzyMatching domain.FuzzyMatchi
 		}
 	}
 
+	requestSource := requestRls.Source
+	clientSource := clientRls.Source
 	// normalize WEB-DL down to plain WEB when simplifyWebCompare is enabled
 	if fuzzyMatching.SimplifyWebCompare {
 		requestRls.Source = simplifyWEB(requestRls.Source)
@@ -41,8 +44,8 @@ func compare(requestRls, clientRls rls.Release, fuzzyMatching domain.FuzzyMatchi
 	if requestRls.Source != clientRls.Source {
 		return domain.CompareInfo{
 			StatusCode:   domain.StatusSourceMismatch,
-			RejectValueA: requestRls.Source,
-			RejectValueB: clientRls.Source,
+			RejectValueA: requestSource,
+			RejectValueB: clientSource,
 		}
 	}
 
@@ -81,17 +84,19 @@ func compare(requestRls, clientRls rls.Release, fuzzyMatching domain.FuzzyMatchi
 		}
 	}
 
+	requestHDR := stdslices.Clone(requestRls.HDR)
+	clientHDR := stdslices.Clone(clientRls.HDR)
 	// normalize any HDR format down to plain HDR when simplifyHdrCompare is enabled
 	if fuzzyMatching.SimplifyHdrCompare {
-		requestRls.HDR = slices.SimplifyHDR(requestRls.HDR)
-		clientRls.HDR = slices.SimplifyHDR(clientRls.HDR)
+		requestRls.HDR = slices.SimplifyHDR(stdslices.Clone(requestHDR))
+		clientRls.HDR = slices.SimplifyHDR(stdslices.Clone(clientHDR))
 	}
 
 	if !slices.EqualElements(requestRls.HDR, clientRls.HDR) {
 		return domain.CompareInfo{
 			StatusCode:   domain.StatusHdrMismatch,
-			RejectValueA: requestRls.HDR,
-			RejectValueB: clientRls.HDR,
+			RejectValueA: requestHDR,
+			RejectValueB: clientHDR,
 		}
 	}
 

--- a/internal/release/release_test.go
+++ b/internal/release/release_test.go
@@ -8,8 +8,70 @@ import (
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 
+	"github.com/autobrr/rls"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCheckCandidatesPreservesOriginalFuzzyMismatchValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("source", func(t *testing.T) {
+		t.Parallel()
+
+		result := CheckCandidates(
+			rls.Release{Type: rls.Series, Source: "WEB-DL"},
+			rls.Release{Type: rls.Episode, Source: "BluRay"},
+			domain.FuzzyMatching{SimplifyWebCompare: true},
+		)
+
+		require.Equal(t, domain.StatusSourceMismatch, result.StatusCode)
+		require.Equal(t, "WEB-DL", result.RejectValueA)
+		require.Equal(t, "BluRay", result.RejectValueB)
+	})
+
+	t.Run("HDR", func(t *testing.T) {
+		t.Parallel()
+
+		request := rls.Release{Type: rls.Series, HDR: []string{"HDR10"}}
+		client := rls.Release{Type: rls.Episode, HDR: []string{"DV"}}
+		result := CheckCandidates(request, client, domain.FuzzyMatching{SimplifyHdrCompare: true})
+
+		require.Equal(t, domain.StatusHdrMismatch, result.StatusCode)
+		require.Equal(t, []string{"HDR10"}, result.RejectValueA)
+		require.Equal(t, []string{"DV"}, result.RejectValueB)
+		require.Equal(t, []string{"HDR10"}, request.HDR)
+		require.Equal(t, []string{"DV"}, client.HDR)
+	})
+}
+
+func TestCheckCandidatesStillAcceptsNormalizedFuzzyValues(t *testing.T) {
+	t.Parallel()
+
+	t.Run("source", func(t *testing.T) {
+		t.Parallel()
+
+		result := CheckCandidates(
+			rls.Release{Type: rls.Series, Source: "WEB-DL"},
+			rls.Release{Type: rls.Episode, Episode: 1, Source: "WEB"},
+			domain.FuzzyMatching{SimplifyWebCompare: true},
+		)
+
+		require.Equal(t, domain.StatusSuccessfulMatch, result.StatusCode)
+	})
+
+	t.Run("HDR", func(t *testing.T) {
+		t.Parallel()
+
+		result := CheckCandidates(
+			rls.Release{Type: rls.Series, HDR: []string{"HDR10"}},
+			rls.Release{Type: rls.Episode, Episode: 1, HDR: []string{"HDR10+"}},
+			domain.FuzzyMatching{SimplifyHdrCompare: true},
+		)
+
+		require.Equal(t, domain.StatusSuccessfulMatch, result.StatusCode)
+	})
+}
 
 func Test_MatchEpToSeasonPackEp(t *testing.T) {
 	type args struct {

--- a/internal/torrentclient/client.go
+++ b/internal/torrentclient/client.go
@@ -105,6 +105,39 @@ const (
 	ImportStageResume                     // resuming the torrent
 )
 
+func (s ImportStage) String() string {
+	switch s {
+	case ImportStageConfig:
+		return "config"
+	case ImportStageAdd:
+		return "add"
+	case ImportStageFind:
+		return "find"
+	case ImportStageRecheck:
+		return "recheck"
+	case ImportStageResume:
+		return "resume"
+	default:
+		return "unknown"
+	}
+}
+
+// ImportStageReport records one successful or failed client-import stage.
+type ImportStageReport struct {
+	Stage    ImportStage
+	Duration time.Duration
+}
+
+// ImportReport describes the client work attempted before Import returned.
+// Stages stay in execution order.
+type ImportReport struct {
+	Stages []ImportStageReport
+}
+
+func (r *ImportReport) record(stage ImportStage, started time.Time) {
+	r.Stages = append(r.Stages, ImportStageReport{Stage: stage, Duration: time.Since(started)})
+}
+
 // ImportError tags an import failure with the stage it happened in.
 type ImportError struct {
 	Stage ImportStage
@@ -151,14 +184,15 @@ func ImportStatusCode(err error) domain.StatusCode {
 // ensures its already-present hardlinked data is accounted for (skip-check +
 // conditional recheck on qBittorrent, forced verify on Transmission, Deluge's
 // normal initial check) and starts it without leaving the import paused.
-// Import failures are returned as *ImportError.
+// Import returns neutral stage timings in execution order. Import failures are
+// returned as *ImportError together with the attempted stage timings.
 type TorrentClient interface {
 	GetTorrents() ([]Torrent, error)
 	// GetFiles returns exactly one result per input hash in input order. Each
 	// adapter owns its safe batching or concurrency strategy.
 	GetFiles(hashes []string) []FileResult
 	ImportDestination() (ImportDestination, error)
-	Import(req ImportRequest) error
+	Import(req ImportRequest) (ImportReport, error)
 }
 
 func fileResultsWithError(hashes []string, err error) []FileResult {

--- a/internal/torrentclient/client_test.go
+++ b/internal/torrentclient/client_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 )
 
+func importStageNames(report ImportReport) []ImportStage {
+	stages := make([]ImportStage, len(report.Stages))
+	for index, stage := range report.Stages {
+		stages[index] = stage.Stage
+	}
+	return stages
+}
+
 func TestBuildTransmissionURL(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/torrentclient/deluge.go
+++ b/internal/torrentclient/deluge.go
@@ -260,15 +260,20 @@ func (d *delugeClient) ImportDestination() (ImportDestination, error) {
 
 // Import adds the pack stopped, applies its optional label, then resumes it.
 // Deluge/libtorrent performs its normal initial data check before it transfers
-// pieces. The adapter waits until the torrent is no longer paused or checking.
-func (d *delugeClient) Import(req ImportRequest) error {
+// pieces. The adapter waits until the torrent is no longer paused or checking
+// and returns the duration of each client operation.
+func (d *delugeClient) Import(req ImportRequest) (ImportReport, error) {
+	var report ImportReport
+	started := time.Now()
 	if !req.HasV1 || strings.TrimSpace(req.LegacyHash) == "" {
-		return importErr(ImportStageConfig, errors.New("deluge requires a v1 or hybrid torrent"))
+		report.record(ImportStageConfig, started)
+		return report, importErr(ImportStageConfig, errors.New("deluge requires a v1 or hybrid torrent"))
 	}
 
 	savePath := strings.TrimSpace(req.SavePath)
 	if savePath == "" {
-		return importErr(ImportStageConfig, errors.New("resolved deluge save path is empty"))
+		report.record(ImportStageConfig, started)
+		return report, importErr(ImportStageConfig, errors.New("resolved deluge save path is empty"))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.checkTimeout)
@@ -280,35 +285,47 @@ func (d *delugeClient) Import(req ImportRequest) error {
 		AddPaused:        &paused,
 	}
 	content := base64.StdEncoding.EncodeToString(req.TorrentBytes)
+	report.record(ImportStageConfig, started)
 
+	started = time.Now()
 	d.mu.Lock()
 	addedHash, err := d.c.AddTorrentFile(ctx, req.LegacyHash+".torrent", content, options)
 	d.mu.Unlock()
 	if isDelugeAlreadyAdded(err) {
-		return nil
+		report.record(ImportStageAdd, started)
+		return report, nil
 	}
 	if err != nil {
-		return importErr(ImportStageAdd, errors.Wrap(err, "failed to add torrent to deluge"))
+		report.record(ImportStageAdd, started)
+		return report, importErr(ImportStageAdd, errors.Wrap(err, "failed to add torrent to deluge"))
 	}
 	if strings.TrimSpace(addedHash) == "" {
-		return nil
+		report.record(ImportStageAdd, started)
+		return report, nil
 	}
 	if err := d.applyLabel(ctx, addedHash); err != nil {
-		return importErr(ImportStageAdd, err)
+		report.record(ImportStageAdd, started)
+		return report, importErr(ImportStageAdd, err)
 	}
+	report.record(ImportStageAdd, started)
 
+	started = time.Now()
 	d.mu.Lock()
 	err = d.c.ResumeTorrents(ctx, addedHash)
 	d.mu.Unlock()
+	report.record(ImportStageResume, started)
 	if err != nil {
-		return importErr(ImportStageResume, errors.Wrap(err, "failed to resume torrent in deluge"))
+		return report, importErr(ImportStageResume, errors.Wrap(err, "failed to resume torrent in deluge"))
 	}
 
+	started = time.Now()
 	if err := d.waitForStarted(ctx, addedHash); err != nil {
-		return importErr(ImportStageRecheck, err)
+		report.record(ImportStageRecheck, started)
+		return report, importErr(ImportStageRecheck, err)
 	}
+	report.record(ImportStageRecheck, started)
 
-	return nil
+	return report, nil
 }
 
 func (d *delugeClient) applyLabel(ctx context.Context, hash string) error {

--- a/internal/torrentclient/deluge_live_test.go
+++ b/internal/torrentclient/deluge_live_test.go
@@ -145,7 +145,7 @@ func TestDelugeImportLive(t *testing.T) {
 
 func importAndRegisterCleanup(t *testing.T, c *delugeClient, raw delugeLiveAPI, req ImportRequest) {
 	t.Helper()
-	if err := c.Import(req); err != nil {
+	if _, err := c.Import(req); err != nil {
 		t.Fatalf("import: %v", err)
 	}
 	t.Cleanup(func() {

--- a/internal/torrentclient/deluge_test.go
+++ b/internal/torrentclient/deluge_test.go
@@ -122,7 +122,7 @@ func TestDelugeImportAppliesLowercaseLabel(t *testing.T) {
 	})
 	client.label = func(context.Context) (delugeLabelAPI, error) { return plugin, nil }
 
-	err := client.Import(ImportRequest{
+	_, err := client.Import(ImportRequest{
 		TorrentBytes: []byte("torrent bytes"),
 		SavePath:     "/downloads/tv",
 		LegacyHash:   "legacy-hash",
@@ -282,13 +282,19 @@ func TestDelugeImportResumesThenWaitsForCheck(t *testing.T) {
 	client := newTestDelugeClient(stub, domain.ImportPolicy{SavePath: "/downloads/tv"})
 	torrentBytes := []byte("torrent bytes")
 
-	err := client.Import(ImportRequest{
+	report, err := client.Import(ImportRequest{
 		TorrentBytes: torrentBytes,
 		SavePath:     "/downloads/tv",
 		LegacyHash:   "legacy-hash",
 		HasV1:        true,
 	})
 	require.NoError(t, err)
+	require.Equal(t, []ImportStage{
+		ImportStageConfig,
+		ImportStageAdd,
+		ImportStageResume,
+		ImportStageRecheck,
+	}, importStageNames(report))
 	require.Equal(t, "legacy-hash.torrent", stub.addedName)
 	require.Equal(t, base64.StdEncoding.EncodeToString(torrentBytes), stub.addedContent)
 	require.NotNil(t, stub.addedOptions)
@@ -302,7 +308,7 @@ func TestDelugeImportRejectsPureV2Torrent(t *testing.T) {
 	t.Parallel()
 
 	client := newTestDelugeClient(&stubDelugeAPI{}, domain.ImportPolicy{SavePath: "/downloads/tv"})
-	err := client.Import(ImportRequest{SavePath: "/downloads/tv", V2Hash: "v2-hash"})
+	_, err := client.Import(ImportRequest{SavePath: "/downloads/tv", V2Hash: "v2-hash"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "v1 or hybrid")
 	require.Equal(t, domain.StatusImportConfigError, ImportStatusCode(err))
@@ -320,7 +326,7 @@ func TestDelugeImportDoesNotMutateExistingV2Torrent(t *testing.T) {
 	}
 	client := newTestDelugeClient(stub, domain.ImportPolicy{SavePath: "/downloads/tv"})
 
-	err := client.Import(ImportRequest{
+	_, err := client.Import(ImportRequest{
 		TorrentBytes: []byte("torrent bytes"),
 		SavePath:     "/downloads/tv",
 		LegacyHash:   "legacy-hash",
@@ -338,7 +344,7 @@ func TestDelugeImportDoesNotMutateExistingV1Torrent(t *testing.T) {
 	}
 	client := newTestDelugeClient(stub, domain.ImportPolicy{SavePath: "/downloads/tv"})
 
-	err := client.Import(ImportRequest{
+	_, err := client.Import(ImportRequest{
 		TorrentBytes: []byte("torrent bytes"),
 		SavePath:     "/downloads/tv",
 		LegacyHash:   "legacy-hash",

--- a/internal/torrentclient/import_live_test.go
+++ b/internal/torrentclient/import_live_test.go
@@ -201,7 +201,7 @@ func TestQbitImportLive(t *testing.T) {
 	packName, torrentBytes, hashes := buildLivePack(t, importDir, "LiveQbit.S01.1080p.WEB-DL.H.264-RlsGrp", 3)
 	t.Logf("importing pack %q hash=%s", packName, hashes.Legacy)
 
-	if err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
+	if _, err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
 		t.Fatalf("qbit Import: %v", err)
 	}
 	requireQbitStarted(t, c, hashes.Legacy)
@@ -310,7 +310,7 @@ func TestTransmissionImportLive(t *testing.T) {
 	packName, torrentBytes, hashes := buildLivePack(t, importDir, "LiveTransmission.S01.1080p.WEB-DL.H.264-RlsGrp", 3)
 	t.Logf("importing pack %q hash=%s", packName, hashes.Legacy)
 
-	if err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
+	if _, err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
 		t.Fatalf("transmission Import: %v", err)
 	}
 	requireTransmissionStarted(t, c, hashes.Legacy)

--- a/internal/torrentclient/import_partial_live_test.go
+++ b/internal/torrentclient/import_partial_live_test.go
@@ -129,7 +129,7 @@ func TestQbitImportPartialLive(t *testing.T) {
 	}
 
 	_, torrentBytes, hashes := buildPartialPack(t, importDir, "AdapterPartialQbit.S01.1080p.WEB-DL.H.264-RlsGrp", 3)
-	if err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
+	if _, err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
 		t.Fatalf("Import: %v", err)
 	}
 
@@ -180,7 +180,7 @@ func TestTransmissionImportPartialLive(t *testing.T) {
 	}
 
 	packName, torrentBytes, hashes := buildPartialPack(t, importDir, "AdapterPartialTr.S01.1080p.WEB-DL.H.264-RlsGrp", 3)
-	if err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
+	if _, err := c.Import(ImportRequest{TorrentBytes: torrentBytes, LegacyHash: hashes.Legacy, V2Hash: hashes.V2, HasV1: hashes.HasV1, SavePath: importDir}); err != nil {
 		t.Fatalf("Import: %v", err)
 	}
 

--- a/internal/torrentclient/qbittorrent.go
+++ b/internal/torrentclient/qbittorrent.go
@@ -234,16 +234,21 @@ func (q *qbitClient) resolveCategorySavePath(categoryName string, categories map
 // Import adds the parsed season pack back to qBittorrent with the hash check
 // skipped (the matched episodes are already hardlinked into place), rechecks it
 // if qBittorrent reports missing files, then resumes it unless the client is
-// configured to leave it paused.
-func (q *qbitClient) Import(req ImportRequest) error {
+// configured to leave it paused. The returned report identifies how long each
+// client operation took.
+func (q *qbitClient) Import(req ImportRequest) (ImportReport, error) {
+	var report ImportReport
+	started := time.Now()
 	opts, err := q.buildTorrentAddOptions()
 	if err != nil {
-		return err
+		report.record(ImportStageConfig, started)
+		return report, err
 	}
 
 	resolvedSavePath := strings.TrimSpace(req.SavePath)
 	if resolvedSavePath == "" {
-		return importErr(ImportStageConfig, errors.New("resolved qbittorrent save path is empty"))
+		report.record(ImportStageConfig, started)
+		return report, importErr(ImportStageConfig, errors.New("resolved qbittorrent save path is empty"))
 	}
 
 	// Category-only policy leaves path selection and Auto TMM to qBittorrent.
@@ -253,44 +258,58 @@ func (q *qbitClient) Import(req ImportRequest) error {
 		opts.SavePath = resolvedSavePath
 	}
 
-	if _, err := q.c.AddTorrentFromMemory(req.TorrentBytes, opts.Prepare()); err != nil {
-		return importErr(ImportStageAdd, errors.Wrap(err, "failed to add torrent to qbittorrent"))
-	}
-
 	lookupHash := req.LegacyHash
 	if !req.HasV1 {
 		lookupHash = req.V2Hash
 	}
 	if strings.TrimSpace(lookupHash) == "" {
-		return importErr(ImportStageConfig, errors.New("resolved qbittorrent info hash is empty"))
+		report.record(ImportStageConfig, started)
+		return report, importErr(ImportStageConfig, errors.New("resolved qbittorrent info hash is empty"))
 	}
 
+	report.record(ImportStageConfig, started)
+
+	started = time.Now()
+	if _, err := q.c.AddTorrentFromMemory(req.TorrentBytes, opts.Prepare()); err != nil {
+		report.record(ImportStageAdd, started)
+		return report, importErr(ImportStageAdd, errors.Wrap(err, "failed to add torrent to qbittorrent"))
+	}
+	report.record(ImportStageAdd, started)
+
+	started = time.Now()
 	added, err := q.waitForTorrent(lookupHash)
+	report.record(ImportStageFind, started)
 	if err != nil {
-		return importErr(ImportStageFind, err)
+		return report, importErr(ImportStageFind, err)
 	}
 
 	if added.State == qbittorrent.TorrentStateMissingFiles {
+		started = time.Now()
 		if err := q.c.Recheck([]string{added.Hash}); err != nil {
-			return importErr(ImportStageRecheck, errors.Wrap(err, "failed to recheck torrent"))
+			report.record(ImportStageRecheck, started)
+			return report, importErr(ImportStageRecheck, errors.Wrap(err, "failed to recheck torrent"))
 		}
 
 		added, err = q.waitForRecheck(added.Hash)
+		report.record(ImportStageRecheck, started)
 		if err != nil {
-			return importErr(ImportStageRecheck, err)
+			return report, importErr(ImportStageRecheck, err)
 		}
 	}
 
 	// a correctly imported torrent always starts once its data is accounted for
 	if isActiveTorrentState(added.State) {
-		return nil
+		return report, nil
 	}
 
+	started = time.Now()
 	if err := q.c.Resume([]string{added.Hash}); err != nil {
-		return importErr(ImportStageResume, errors.Wrap(err, "failed to resume torrent"))
+		report.record(ImportStageResume, started)
+		return report, importErr(ImportStageResume, errors.Wrap(err, "failed to resume torrent"))
 	}
+	report.record(ImportStageResume, started)
 
-	return nil
+	return report, nil
 }
 
 // buildTorrentAddOptions maps the client's import policy onto qBittorrent add

--- a/internal/torrentclient/qbittorrent_test.go
+++ b/internal/torrentclient/qbittorrent_test.go
@@ -359,7 +359,7 @@ func TestQbitImportRechecksMissingFilesThenResumes(t *testing.T) {
 	}
 	q := newTestQbitClient(stub, domain.ImportPolicy{Category: "tv-hd", Tags: []string{"seasonpackarr"}})
 
-	err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
+	_, err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
 	require.NoError(t, err)
 
 	require.NotEmpty(t, stub.addBytes)
@@ -414,7 +414,7 @@ func TestQbitImportAutomaticManagementOption(t *testing.T) {
 			}
 			q := newTestQbitClient(stub, tt.policy)
 
-			err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
+			_, err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
 			require.NoError(t, err)
 			gotSavePath, savePresent := stub.addOptions["savepath"]
 			require.Equal(t, tt.wantSavePresent, savePresent)
@@ -443,10 +443,17 @@ func TestQbitImportWaitsForCheckingToSettle(t *testing.T) {
 	}
 	q := newTestQbitClient(stub, domain.ImportPolicy{Category: "tv-hd"})
 
-	err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
+	report, err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
 	require.NoError(t, err)
 	require.Len(t, stub.recheckCalls, 1, "recheck must run once missingFiles is observed")
 	require.Len(t, stub.resumeCalls, 1)
+	require.Equal(t, []ImportStage{
+		ImportStageConfig,
+		ImportStageAdd,
+		ImportStageFind,
+		ImportStageRecheck,
+		ImportStageResume,
+	}, importStageNames(report))
 }
 
 func TestQbitImportSkipsResumeWhenAlreadyActive(t *testing.T) {
@@ -458,8 +465,13 @@ func TestQbitImportSkipsResumeWhenAlreadyActive(t *testing.T) {
 	}
 	q := newTestQbitClient(stub, domain.ImportPolicy{Category: "tv-hd"})
 
-	err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
+	report, err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv-hd"})
 	require.NoError(t, err)
+	require.Equal(t, []ImportStage{
+		ImportStageConfig,
+		ImportStageAdd,
+		ImportStageFind,
+	}, importStageNames(report))
 	require.Empty(t, stub.recheckCalls)
 	require.Empty(t, stub.resumeCalls, "already-active torrent must not be resumed")
 }
@@ -476,7 +488,7 @@ func TestQbitImportUsesV2HashForPureV2Torrent(t *testing.T) {
 	}
 	q := newTestQbitClient(stub, domain.ImportPolicy{SavePath: "/data/tv-hd"})
 
-	err := q.Import(ImportRequest{
+	_, err := q.Import(ImportRequest{
 		TorrentBytes: []byte("torrent"),
 		SavePath:     "/data/tv-hd",
 		LegacyHash:   legacyHash,
@@ -487,4 +499,15 @@ func TestQbitImportUsesV2HashForPureV2Torrent(t *testing.T) {
 	require.NotEmpty(t, stub.lookups)
 	require.Equal(t, []string{v2Hash}, stub.lookups[0])
 	require.Equal(t, [][]string{{v2Hash}}, stub.resumeCalls)
+}
+
+func TestQbitImportRejectsMissingHashBeforeAdd(t *testing.T) {
+	stub := &stubQbitAPI{}
+	q := newTestQbitClient(stub, domain.ImportPolicy{SavePath: "/data/tv-hd"})
+
+	report, err := q.Import(ImportRequest{TorrentBytes: []byte("torrent"), HasV1: true, SavePath: "/data/tv-hd"})
+	require.Error(t, err)
+	require.Equal(t, domain.StatusImportConfigError, ImportStatusCode(err))
+	require.Equal(t, []ImportStage{ImportStageConfig}, importStageNames(report))
+	require.Empty(t, stub.addBytes)
 }

--- a/internal/torrentclient/transmission.go
+++ b/internal/torrentclient/transmission.go
@@ -172,10 +172,14 @@ func (t *transmissionClient) ImportDestination() (ImportDestination, error) {
 //
 // Transmission has no skip-hash-check equivalent (verified against 4.0.6 and
 // 4.1.3), so the import always verifies. Only the genuinely missing pieces are
-// downloaded once started.
-func (t *transmissionClient) Import(req ImportRequest) error {
+// downloaded once started. The returned report identifies how long each client
+// operation took.
+func (t *transmissionClient) Import(req ImportRequest) (ImportReport, error) {
+	var report ImportReport
+	started := time.Now()
 	if strings.TrimSpace(req.LegacyHash) == "" {
-		return importErr(ImportStageConfig, errors.New("resolved transmission info hash is empty"))
+		report.record(ImportStageConfig, started)
+		return report, importErr(ImportStageConfig, errors.New("resolved transmission info hash is empty"))
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), t.verifyTimeout)
@@ -193,25 +197,36 @@ func (t *transmissionClient) Import(req ImportRequest) error {
 	if labels := trimStrings(t.policy.Tags); len(labels) > 0 {
 		payload.Labels = labels
 	}
+	report.record(ImportStageConfig, started)
 
+	started = time.Now()
 	if _, err := t.c.TorrentAdd(ctx, payload); err != nil {
-		return importErr(ImportStageAdd, errors.Wrap(err, "failed to add torrent to transmission"))
+		report.record(ImportStageAdd, started)
+		return report, importErr(ImportStageAdd, errors.Wrap(err, "failed to add torrent to transmission"))
 	}
+	report.record(ImportStageAdd, started)
 
+	started = time.Now()
 	if err := t.c.TorrentVerifyHashes(ctx, []string{req.LegacyHash}); err != nil {
-		return importErr(ImportStageRecheck, errors.Wrap(err, "failed to verify torrent"))
+		report.record(ImportStageRecheck, started)
+		return report, importErr(ImportStageRecheck, errors.Wrap(err, "failed to verify torrent"))
 	}
 
 	if err := t.waitForVerify(ctx, req.LegacyHash); err != nil {
-		return importErr(ImportStageRecheck, err)
+		report.record(ImportStageRecheck, started)
+		return report, importErr(ImportStageRecheck, err)
 	}
+	report.record(ImportStageRecheck, started)
 
 	// a correctly imported torrent always starts once verification has settled
+	started = time.Now()
 	if err := t.c.TorrentStartHashes(ctx, []string{req.LegacyHash}); err != nil {
-		return importErr(ImportStageResume, errors.Wrap(err, "failed to start torrent"))
+		report.record(ImportStageResume, started)
+		return report, importErr(ImportStageResume, errors.Wrap(err, "failed to start torrent"))
 	}
+	report.record(ImportStageResume, started)
 
-	return nil
+	return report, nil
 }
 
 // waitForVerify polls until the torrent leaves the checking states. Because the

--- a/internal/torrentclient/transmission_import_test.go
+++ b/internal/torrentclient/transmission_import_test.go
@@ -94,8 +94,14 @@ func TestTransmissionImportVerifiesThenStarts(t *testing.T) {
 	}
 	tc := newTestTransmissionClient(stub, domain.ImportPolicy{SavePath: "/data/tv", Tags: []string{"seasonpackarr"}})
 
-	err := tc.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv"})
+	report, err := tc.Import(ImportRequest{TorrentBytes: []byte("torrent"), LegacyHash: hash, HasV1: true, SavePath: "/data/tv"})
 	require.NoError(t, err)
+	require.Equal(t, []ImportStage{
+		ImportStageConfig,
+		ImportStageAdd,
+		ImportStageRecheck,
+		ImportStageResume,
+	}, importStageNames(report))
 
 	require.True(t, stub.addCalled)
 	require.NotNil(t, stub.addPayload.MetaInfo)
@@ -118,7 +124,7 @@ func TestTransmissionImportFailsOnError(t *testing.T) {
 	}
 	tc := newTestTransmissionClient(stub, domain.ImportPolicy{SavePath: "/data/tv"})
 
-	err := tc.Import(ImportRequest{TorrentBytes: []byte("t"), LegacyHash: "h", HasV1: true, SavePath: "/data/tv"})
+	_, err := tc.Import(ImportRequest{TorrentBytes: []byte("t"), LegacyHash: "h", HasV1: true, SavePath: "/data/tv"})
 	require.Error(t, err)
 	require.Equal(t, domain.StatusRecheckTorrentError, ImportStatusCode(err))
 	require.Empty(t, stub.startCalls)


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #252

Followed by:
- #254
<!-- ship-stack:end -->

## Motivation

Pack logs reported only aggregate reusable episode coverage. They did not explain why torrent episodes were not reusable. Parse logs could show a long request, such as a 36-second import, without identifying the slow torrent-client stage.

## What's new

- Report one compact structured reason for each unmatched torrent episode.
- Use `want` for announced requirements and `got` for client values, including original values when fuzzy matching normalizes comparisons.
- Report reusable, unmatched, total, coverage, and smart-mode threshold values.
- Measure attempted torrent-client import stages with stable `config`, `add`, `find`, `recheck`, and `resume` names.
- Report plan source, destination resolution, hardlink work, client-import time, and total parse time, including failure paths.
- Treat expected candidate and pack gate rejections as informational events while technical failures remain errors.
- Keep successful match selection, smart-mode acceptance, endpoint side effects, and credential handling unchanged.

## Tests

- Matcher diagnostics for missing sources, compatibility mismatches, duplicate targets, and all `want` and `got` fields.
- Fuzzy WEB and HDR tests for original diagnostic values and normalized acceptance.
- qBittorrent, Transmission, and Deluge import-stage reports, including failed and skipped stages.
- Authenticated candidate, pack, and parse log regression coverage for success and failure paths.
- `go test -v ./...`
- `go test -race ./internal/release ./internal/http ./internal/torrentclient`
- `go vet ./...`
- `govulncheck ./...`
