### PR TITLE
fix: recover from moved hardlink sources

### DIFF
--- a/docs/design-docs/matching-and-hardlinking.md
+++ b/docs/design-docs/matching-and-hardlinking.md
@@ -19,6 +19,10 @@ Current comparison logic checks:
 - do not link when the pack file is not a real episode video
 - do not link when file sizes disagree for episode-to-pack matching
 - path naming must reflect the pack folder users actually need, not just the announce title when parsing is enabled
+- if a planned source disappears before linking, refresh the client inventory
+  and exact plan once before the import fails
+- keep the refresh bounded; repeated source movement must not create an
+  unbounded retry loop
 
 ## Safety Expectations
 

--- a/docs/design-docs/season-pack-lifecycle.md
+++ b/docs/design-docs/season-pack-lifecycle.md
@@ -11,12 +11,12 @@ Describe the normal path from webhook hit to hardlink creation and client import
 3. `internal/http/server.go` exposes authenticated `/api/candidate`, `/api/pack`, and `/api/parse`.
 4. A webhook request enters `internal/http/webhook.go`.
 5. `internal/http/processor_handlers.go` decodes the payload. The candidate, plan, and import processor files keep the three lifecycle stages separate.
-6. `/api/candidate` compares the announce with cached torrent summaries. It does not read torrent bytes or file details.
+6. `/api/candidate` compares the announce with cached torrent summaries. It does not read torrent bytes or file details. At debug level, it logs each client release that caused the gate to pass.
 7. `/api/pack` reuses the short-lived inventory, parses the announced torrent, and requests details only for candidate client torrents.
 8. `internal/release/` keeps MKV and MP4 files that parse as episodes. It excludes samples, extra videos, and other non-episode files from coverage.
 9. Reusable source files map to distinct valid targets with the same container under configured fuzzy rules.
 10. Smart mode compares the exact reusable target count with the actual torrent episode count. `/api/pack` caches an accepted side-effect-free plan.
-11. `/api/parse` reuses that plan, or safely rebuilds it after a cache miss. It resolves the import destination and hardlinks matching files in the client-selected layout.
+11. `/api/parse` reuses that plan, or safely rebuilds it after a cache miss. It resolves the import destination and hardlinks matching files in the client-selected layout. If a planned source disappeared because the client moved it, the processor invalidates both caches, rebuilds the exact plan, and retries the idempotent links once.
 12. Smart mode checks achieved coverage after hardlink creation. If it is below the threshold, the request does not import the torrent. Successful hardlinks remain for a safe retry. Automatic cleanup is intentionally deferred because the service cannot yet prove ownership of every file and directory it would remove.
 13. The torrent is added to the client, checked so the present files are recognised, and not left paused. See
     [qbittorrent-import-flow.md](qbittorrent-import-flow.md) for the complete-vs-partial
@@ -37,4 +37,4 @@ Describe the normal path from webhook hit to hardlink creation and client import
 
 ## Verification Notes
 
-Verified against code on 2026-08-12. The lifecycle is implementation-backed, not aspirational.
+Verified against code on 2026-08-20. The lifecycle is implementation-backed, not aspirational.

--- a/docs/exec-plans/completed/2026-08-20-stale-source-recovery.md
+++ b/docs/exec-plans/completed/2026-08-20-stale-source-recovery.md
@@ -1,0 +1,85 @@
+# Stale hardlink source recovery
+
+## goal
+
+Show which client releases pass the candidate gate. Recover when a client
+moves a planned episode before `/api/parse` creates its hardlink.
+
+## scope
+
+- debug-log each client release that passes `/api/candidate`
+- detect a missing planned source during hardlinking
+- refresh the client inventory and exact plan once, then retry hardlinking
+- add authenticated HTTP regression coverage
+- update lifecycle and operator documentation
+
+## non-goals
+
+- prevent Sonarr or a torrent client from moving files
+- retry non-path hardlink errors
+- add configuration
+- remove hardlinks created before an aborted import
+
+## risks
+
+- repeated retries could hide an unstable client, so recovery is bounded to one
+  refresh
+- a refreshed plan can have lower coverage, so it must pass the planned and
+  achieved coverage checks before import
+- successful links from the first attempt remain on disk and must be accepted
+  as idempotent successes during the retry
+
+## steps
+
+1. Capture the production symptom and add failing component tests. [done]
+2. Prove whether plan-only or plan-plus-inventory refresh is required. [done]
+3. Implement candidate debug logs and bounded stale-source recovery. [done]
+4. Update docs and run focused and full verification. [done]
+5. Review the final diff and complete this plan. [done]
+6. Address independent review findings for cache and coverage helpers,
+   structured missing-source logs, cause-neutral test naming, and explicit
+   repeated-move coverage. [done]
+
+## decision log
+
+- 2026-08-20: Hades logs confirm an accepted plan referenced a source path that
+  disappeared before hardlinking. Seven links succeeded before the stale link
+  reduced coverage below the configured threshold.
+- 2026-08-20: a deterministic minimal one-episode component test reproduces
+  status 440 after moving the source between `/api/pack` and `/api/parse`. The
+  final regression uses two episodes to also verify idempotent retry after one
+  link already succeeded.
+- 2026-08-20: invalidating only the accepted plan retains the stale 30-second
+  inventory. Recovery must invalidate both caches.
+- 2026-08-20: retry all refreshed links once. `CreateHardlink` accepts an
+  existing link to the same file, so links from the first attempt are safe and
+  count toward achieved coverage.
+- 2026-08-20: check refreshed planned coverage before retry and achieved
+  coverage after retry. Do not import a refreshed plan below the configured
+  threshold.
+- 2026-08-20: independent review found no production defect or hard standards
+  violation. Follow-up work centralizes coupled cache invalidation and planned
+  coverage checks, makes the missing-source log structured, and locks down the
+  one-refresh limit when a source moves again.
+
+## verification notes
+
+- Red command:
+  `go test ./internal/http -run 'TestAuthenticatedCandidateLogsEachMatchingClientReleaseAtDebug|TestAuthenticatedParseRefreshesPlanWhenSourceMoves' -count=2`
+- Before the fix, both tests fail deterministically.
+- The focused candidate, moved-source, and refreshed-threshold tests pass three
+  consecutive runs.
+- `go test ./internal/http` passes.
+- `go test -race ./internal/http` passes.
+- `go test -v ./...` passes.
+- `go vet ./...` passes.
+- `govulncheck ./...` reports no called-code or imported-package
+  vulnerabilities. One required-module vulnerability is not called.
+- `gofumpt -w .` and `git diff --check` pass.
+- Final review found no unbounded retry, threshold bypass, or unrelated file
+  modification. The existing untracked release-parser audit was preserved.
+- Review follow-up verification: focused authenticated endpoint tests pass
+  three consecutive runs, `go test -v ./...`, `go test -race
+  ./internal/http`, `go vet ./...`, `govulncheck ./...`, `gofumpt -w .`, and
+  `git diff --check` pass.
+- The final independent Standards and Spec reviews report no findings.

--- a/docs/product-specs/webhook-contract.md
+++ b/docs/product-specs/webhook-contract.md
@@ -14,7 +14,7 @@ Requests must include the configured API token. Unauthorized requests are reject
 
 - `/api/candidate` is an announce-only match gate. It reads torrent summaries but never requests torrent bytes or per-torrent file details.
 - `/api/pack` requires torrent bytes. It counts MKV and MP4 files that parse as episodes, excludes samples and extra videos, maps reusable client files to distinct same-container targets, applies smart-mode coverage, and caches an accepted import plan. It has no filesystem or client side effects.
-- `/api/parse` owns the import. It reuses the accepted plan when available and safely rebuilds it on a cache miss. It resolves the client destination, hardlinks matched episodes, and imports through the per-client policy. If achieved smart-mode coverage falls below the threshold, it does not import. Successful hardlinks remain for a safe retry; the service does not perform destructive cleanup.
+- `/api/parse` owns the import. It reuses the accepted plan when available and safely rebuilds it on a cache miss. If a planned source disappears during hardlinking, it refreshes the client inventory and exact plan once, then retries the idempotent hardlink set. It resolves the client destination, hardlinks matched episodes, and imports through the per-client policy. If achieved smart-mode coverage falls below the threshold, it does not import. Successful hardlinks remain for a safe retry; the service does not perform destructive cleanup.
 - The candidate and pack checks share a short-lived client inventory. A normal candidate, pack, parse sequence performs one inventory scan and one set of candidate file-detail reads.
 
 ## Operator Log Contract
@@ -23,6 +23,7 @@ Requests must include the configured API token. Unauthorized requests are reject
   event. The event reports the incompatible field, the original announced
   `want` value, the original client `got` value, and the client release. Fuzzy
   matching can normalize values for comparison but not for diagnostics.
+- When `/api/candidate` passes, it logs each matching client release at `DEBUG`.
 - `/api/pack` logs the reusable, unmatched, and total torrent episode counts.
 - Each unmatched torrent episode produces one structured log event. The event
   reports either a missing source episode, a duplicate torrent target, or the
@@ -31,7 +32,9 @@ Requests must include the configured API token. Unauthorized requests are reject
 - `/api/parse` logs whether it reused or rebuilt the import plan. It also logs
   each successful or failed destination-resolution attempt at `INFO`, hardlink
   duration, each torrent-client import stage, total client-import duration, and
-  total parse duration.
+  total parse duration. A missing hardlink source logs a static warning with a
+  structured `source` path, followed by the bounded inventory and plan refresh
+  result.
 - Torrent-client stages use the stable names `config`, `add`, `find`,
   `recheck`, and `resume`. A client omits stages that it does not perform.
 - Logs never include configured credentials or request authentication tokens.

--- a/internal/http/processor_candidate.go
+++ b/internal/http/processor_candidate.go
@@ -62,8 +62,14 @@ func (p *processor) candidateSeasonPack() (domain.StatusCode, error) {
 		return domain.StatusClientNotFound, domain.StatusClientNotFound.Error()
 	}
 
-	if _, statusCode, err := p.findCandidates(clientName, clientCfg, snapshot); err != nil {
+	candidates, statusCode, err := p.findCandidates(clientName, clientCfg, snapshot)
+	if err != nil {
 		return statusCode, err
+	}
+	for _, candidate := range candidates {
+		p.log.Debug().
+			Str("client_release", candidate.torrent.Name).
+			Msg("client release passed candidate gate")
 	}
 
 	return domain.StatusSuccessfulMatch, nil

--- a/internal/http/processor_import.go
+++ b/internal/http/processor_import.go
@@ -4,7 +4,10 @@
 package http
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"time"
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
@@ -78,11 +81,8 @@ func (p *processor) parseTorrent() (statusCode domain.StatusCode, err error) {
 		return statusCode, err
 	}
 
-	if snapshot.SmartMode {
-		coverage := release.PercentOfTotalEpisodes(plan.totalEps, len(plan.links))
-		if coverage < snapshot.SmartModeThreshold {
-			return domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
-		}
+	if !plan.meetsPlannedCoverageThreshold(snapshot) {
+		return domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
 	}
 
 	destinationStarted := time.Now()
@@ -101,28 +101,40 @@ func (p *processor) parseTorrent() (statusCode domain.StatusCode, err error) {
 		Msg("import destination resolved")
 
 	hardlinkStarted := time.Now()
-	linkedCount := 0
-	for _, link := range plan.links {
-		targetEpPath := importDestination.TargetPath(plan.packName, link.torrentEpPath)
-		if err = files.CreateHardlink(link.clientEpPath, targetEpPath); err != nil {
-			p.log.Error().Err(err).Msgf("error creating hardlink: %s", link.clientEpPath)
-			continue
+	hardlinkResult := p.createPlanHardlinks(plan, importDestination)
+	if hardlinkResult.sourceMissing {
+		p.log.Warn().Msg("hardlink source disappeared; refreshing client inventory and import plan")
+		invalidateImportCaches(clientName, plan.hashes)
+
+		refreshStarted := time.Now()
+		refreshedPlan, refreshStatusCode, refreshErr := p.buildImportPlan(clientName, clientCfg, snapshot)
+		refreshEvent := p.log.Info().
+			Bool("successful", refreshErr == nil).
+			Int64("duration_ms", time.Since(refreshStarted).Milliseconds())
+		if refreshErr != nil {
+			refreshEvent.Err(refreshErr).Msg("import plan refreshed after missing hardlink source")
+			p.logHardlinkStage(plan, hardlinkResult, hardlinkStarted)
+			return refreshStatusCode, refreshErr
 		}
-		p.log.Info().Msgf("created or reused hardlink: source(%s), target(%s)", link.clientEpPath, targetEpPath)
-		linkedCount++
+		refreshEvent.
+			Int("planned_links", len(refreshedPlan.links)).
+			Int("total_episodes", refreshedPlan.totalEps).
+			Msg("import plan refreshed after missing hardlink source")
+		if !refreshedPlan.meetsPlannedCoverageThreshold(snapshot) {
+			p.logHardlinkStage(plan, hardlinkResult, hardlinkStarted)
+			return domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
+		}
+
+		plan = refreshedPlan
+		hardlinkResult = p.createPlanHardlinks(plan, importDestination)
 	}
 
-	p.log.Info().
-		Int("linked_episodes", linkedCount).
-		Int("planned_links", len(plan.links)).
-		Int("total_episodes", plan.totalEps).
-		Int64("duration_ms", time.Since(hardlinkStarted).Milliseconds()).
-		Msg("hardlink stage completed")
-	if linkedCount == 0 {
+	p.logHardlinkStage(plan, hardlinkResult, hardlinkStarted)
+	if hardlinkResult.linkedCount == 0 {
 		return domain.StatusFailedHardlink, domain.StatusFailedHardlink.Error()
 	}
 	if snapshot.SmartMode {
-		coverage := release.PercentOfTotalEpisodes(plan.totalEps, linkedCount)
+		coverage := release.PercentOfTotalEpisodes(plan.totalEps, hardlinkResult.linkedCount)
 		if coverage < snapshot.SmartModeThreshold {
 			return domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
 		}
@@ -151,8 +163,43 @@ func (p *processor) parseTorrent() (statusCode domain.StatusCode, err error) {
 		return statusCode, fmt.Errorf("%s: %w", statusCode, err)
 	}
 
-	planMap.Delete(importPlanKey(clientName, plan.hashes))
-	entryMap.Delete(clientName)
+	invalidateImportCaches(clientName, plan.hashes)
 
 	return domain.StatusSuccessfulHardlink, nil
+}
+
+type hardlinkAttemptResult struct {
+	linkedCount   int
+	sourceMissing bool
+}
+
+func (p *processor) createPlanHardlinks(plan importPlan, importDestination torrentclient.ImportDestination) hardlinkAttemptResult {
+	result := hardlinkAttemptResult{}
+	for _, link := range plan.links {
+		targetEpPath := importDestination.TargetPath(plan.packName, link.torrentEpPath)
+		if err := files.CreateHardlink(link.clientEpPath, targetEpPath); err != nil {
+			if _, statErr := os.Stat(link.clientEpPath); errors.Is(statErr, fs.ErrNotExist) {
+				result.sourceMissing = true
+				p.log.Warn().
+					Err(err).
+					Str("source", link.clientEpPath).
+					Msg("hardlink source is missing")
+				continue
+			}
+			p.log.Error().Err(err).Msgf("error creating hardlink: %s", link.clientEpPath)
+			continue
+		}
+		p.log.Info().Msgf("created or reused hardlink: source(%s), target(%s)", link.clientEpPath, targetEpPath)
+		result.linkedCount++
+	}
+	return result
+}
+
+func (p *processor) logHardlinkStage(plan importPlan, result hardlinkAttemptResult, started time.Time) {
+	p.log.Info().
+		Int("linked_episodes", result.linkedCount).
+		Int("planned_links", len(plan.links)).
+		Int("total_episodes", plan.totalEps).
+		Int64("duration_ms", time.Since(started).Milliseconds()).
+		Msg("hardlink stage completed")
 }

--- a/internal/http/processor_integration_test.go
+++ b/internal/http/processor_integration_test.go
@@ -247,6 +247,28 @@ func TestAuthenticatedCandidateLogsStructuredCompatibilityMismatch(t *testing.T)
 	require.Equal(t, "Lifecycle.S01E01.1080p.BluRay.H.264-RlsGrp", mismatch["client_release"])
 }
 
+func TestAuthenticatedCandidateLogsEachMatchingClientReleaseAtDebug(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 2, 2, 0.5, newCapturedLogger(&output))
+
+	response := f.postJSON(t, "/api/candidate", map[string]any{
+		"name":       f.releaseName,
+		"clientname": "default",
+	})
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), response.Code)
+
+	logs := decodeCapturedLogs(t, &output)
+	for episode := 1; episode <= 2; episode++ {
+		clientRelease := fmt.Sprintf("Lifecycle.S01E%02d.1080p.WEB-DL.H.264-RlsGrp", episode)
+		matched := requireCapturedLogField(t, logs, "client release passed candidate gate", "client_release", clientRelease)
+		require.Equal(t, "debug", matched["level"])
+	}
+}
+
 func TestAuthenticatedPackLogsUnmatchedTorrentEpisode(t *testing.T) {
 	previousLevel := zerolog.GlobalLevel()
 	zerolog.SetGlobalLevel(zerolog.TraceLevel)
@@ -468,6 +490,125 @@ func TestAuthenticatedHTTPLifecycleReusesAcceptedPlan(t *testing.T) {
 		episodeFile := fmt.Sprintf("Lifecycle.S01E%02d.1080p.WEB-DL.H.264-RlsGrp.mkv", episode)
 		require.FileExists(t, filepath.Join(f.importDir, f.releaseName, episodeFile))
 	}
+}
+
+func TestAuthenticatedParseRefreshesPlanWhenSourceMoves(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 2, 2, 1, newCapturedLogger(&output))
+
+	pack := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), pack.Code)
+
+	episodeFile := "Lifecycle.S01E02.1080p.WEB-DL.H.264-RlsGrp.mkv"
+	movedDir := filepath.Join(filepath.Dir(f.sourceDir), "source-completed")
+	require.NoError(t, os.MkdirAll(movedDir, 0o755))
+	require.NoError(t, os.Rename(
+		filepath.Join(f.sourceDir, episodeFile),
+		filepath.Join(movedDir, episodeFile),
+	))
+	f.mock.torrents[1].SavePath = movedDir
+
+	parse := f.postJSON(t, "/api/parse", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulHardlink.Code(), parse.Code, parse.Body.String())
+	require.Equal(t, 2, f.mock.torrentCalls, "parse must refresh the stale inventory once")
+	require.Equal(t, 4, f.mock.fileCalls, "parse must rebuild the stale plan once")
+	for episode := 1; episode <= 2; episode++ {
+		fileName := fmt.Sprintf("Lifecycle.S01E%02d.1080p.WEB-DL.H.264-RlsGrp.mkv", episode)
+		require.FileExists(t, filepath.Join(f.importDir, f.releaseName, fileName))
+	}
+	require.True(t, f.mock.importCalled)
+
+	logs := decodeCapturedLogs(t, &output)
+	missing := requireCapturedLogField(
+		t,
+		logs,
+		"hardlink source is missing",
+		"source",
+		filepath.Join(f.sourceDir, episodeFile),
+	)
+	require.Equal(t, "warn", missing["level"])
+	refresh := requireCapturedLog(t, logs, "import plan refreshed after missing hardlink source")
+	require.Equal(t, true, refresh["successful"])
+	hardlinks := requireCapturedLog(t, logs, "hardlink stage completed")
+	require.Equal(t, float64(2), hardlinks["linked_episodes"])
+}
+
+func TestAuthenticatedParseRefreshesAtMostOnceWhenSourceMovesAgain(t *testing.T) {
+	previousLevel := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previousLevel) })
+
+	var output bytes.Buffer
+	f := newProcessorHTTPFixtureWithLogger(t, 2, 2, 1, newCapturedLogger(&output))
+
+	pack := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), pack.Code)
+
+	episodeFile := "Lifecycle.S01E02.1080p.WEB-DL.H.264-RlsGrp.mkv"
+	movedDir := filepath.Join(filepath.Dir(f.sourceDir), "source-completed")
+	movedAgainDir := filepath.Join(filepath.Dir(f.sourceDir), "source-moved-again")
+	require.NoError(t, os.MkdirAll(movedDir, 0o755))
+	require.NoError(t, os.MkdirAll(movedAgainDir, 0o755))
+	require.NoError(t, os.Rename(
+		filepath.Join(f.sourceDir, episodeFile),
+		filepath.Join(movedDir, episodeFile),
+	))
+	f.mock.torrents[1].SavePath = movedDir
+	f.mock.afterGetFiles = func() {
+		require.NoError(t, os.Rename(
+			filepath.Join(movedDir, episodeFile),
+			filepath.Join(movedAgainDir, episodeFile),
+		))
+		f.mock.afterGetFiles = nil
+	}
+
+	parse := f.postJSON(t, "/api/parse", f.packPayload())
+	require.Equal(t, domain.StatusBelowThreshold.Code(), parse.Code, parse.Body.String())
+	require.Equal(t, 2, f.mock.torrentCalls, "parse must refresh the inventory only once")
+	require.Equal(t, 4, f.mock.fileCalls, "parse must rebuild the plan only once")
+	require.Zero(t, f.mock.importCalls)
+
+	refreshCount := 0
+	missingCount := 0
+	for _, event := range decodeCapturedLogs(t, &output) {
+		switch event["message"] {
+		case "import plan refreshed after missing hardlink source":
+			refreshCount++
+		case "hardlink source is missing":
+			missingCount++
+		}
+	}
+	require.Equal(t, 1, refreshCount)
+	require.Equal(t, 2, missingCount)
+}
+
+func TestAuthenticatedParseRejectsRefreshedPlanBelowThreshold(t *testing.T) {
+	f := newProcessorHTTPFixture(t, 2, 2, 1)
+
+	pack := f.postJSON(t, "/api/pack", f.packPayload())
+	require.Equal(t, domain.StatusSuccessfulMatch.Code(), pack.Code)
+
+	episodeFile := "Lifecycle.S01E02.1080p.WEB-DL.H.264-RlsGrp.mkv"
+	require.NoError(t, os.Rename(
+		filepath.Join(f.sourceDir, episodeFile),
+		filepath.Join(filepath.Dir(f.sourceDir), episodeFile),
+	))
+	f.mock.torrents = f.mock.torrents[:1]
+
+	parse := f.postJSON(t, "/api/parse", f.packPayload())
+	require.Equal(t, domain.StatusBelowThreshold.Code(), parse.Code, parse.Body.String())
+	require.Equal(t, 2, f.mock.torrentCalls)
+	require.Equal(t, 3, f.mock.fileCalls)
+	require.Zero(t, f.mock.importCalls)
+	require.FileExists(t, filepath.Join(
+		f.importDir,
+		f.releaseName,
+		"Lifecycle.S01E01.1080p.WEB-DL.H.264-RlsGrp.mkv",
+	))
 }
 
 func TestPackCoverageAcceptsMp4EpisodesAndIgnoresExtraVideos(t *testing.T) {

--- a/internal/http/processor_plan.go
+++ b/internal/http/processor_plan.go
@@ -33,6 +33,13 @@ type importPlan struct {
 	totalEps     int
 }
 
+func (plan importPlan) meetsPlannedCoverageThreshold(cfg domain.Config) bool {
+	if !cfg.SmartMode {
+		return true
+	}
+	return release.PercentOfTotalEpisodes(plan.totalEps, len(plan.links)) >= cfg.SmartModeThreshold
+}
+
 type cachedImportPlan struct {
 	plan          importPlan
 	releaseName   string
@@ -68,18 +75,15 @@ func (p *processor) processSeasonPack() (domain.StatusCode, error) {
 	p.log.Info().Msgf("using %s client", clientName)
 
 	plan, statusCode, err := p.buildImportPlan(clientName, clientCfg, snapshot)
-	coverage := float32(0)
 	if plan.totalEps > 0 {
-		coverage = p.logImportPlan(plan, snapshot)
+		p.logImportPlan(plan, snapshot)
 	}
 	if err != nil {
 		return statusCode, err
 	}
 
-	if snapshot.SmartMode {
-		if coverage < snapshot.SmartModeThreshold {
-			return domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
-		}
+	if !plan.meetsPlannedCoverageThreshold(snapshot) {
+		return domain.StatusBelowThreshold, domain.StatusBelowThreshold.Error()
 	}
 
 	p.storeImportPlan(clientName, *clientCfg, snapshot.FuzzyMatching, plan)
@@ -87,7 +91,7 @@ func (p *processor) processSeasonPack() (domain.StatusCode, error) {
 	return domain.StatusSuccessfulMatch, nil
 }
 
-func (p *processor) logImportPlan(plan importPlan, cfg domain.Config) float32 {
+func (p *processor) logImportPlan(plan importPlan, cfg domain.Config) {
 	for _, unmatched := range plan.unmatched {
 		event := p.log.Info().
 			Str("torrent_path", unmatched.TorrentPath).
@@ -119,7 +123,6 @@ func (p *processor) logImportPlan(plan importPlan, cfg domain.Config) float32 {
 		summary = summary.Float32("threshold_percent", cfg.SmartModeThreshold*100)
 	}
 	summary.Msg("season pack import plan built")
-	return coverage
 }
 
 func (p *processor) buildImportPlan(clientName string, clientCfg *domain.Client, cfg domain.Config) (importPlan, domain.StatusCode, error) {
@@ -237,6 +240,11 @@ func episodeFileFromFiles(files []torrentclient.File, savePath string) (release.
 
 func importPlanKey(clientName string, hashes torrents.Hashes) importPlanCacheKey {
 	return importPlanCacheKey{clientName: clientName, hashes: hashes}
+}
+
+func invalidateImportCaches(clientName string, hashes torrents.Hashes) {
+	planMap.Delete(importPlanKey(clientName, hashes))
+	entryMap.Delete(clientName)
 }
 
 func (p *processor) storeImportPlan(clientName string, clientCfg domain.Client, fuzzyMatching domain.FuzzyMatching, plan importPlan) {

--- a/internal/http/processor_test.go
+++ b/internal/http/processor_test.go
@@ -41,6 +41,7 @@ type mockTorrentClient struct {
 	gotHashes      []string
 	fileCalls      int
 	fileBatchCalls int
+	afterGetFiles  func()
 
 	importRoot    string
 	importRootErr error
@@ -91,6 +92,9 @@ func (m *mockTorrentClient) GetFiles(hashes []string) []torrentclient.FileResult
 			continue
 		}
 		results[index].Files = m.files
+	}
+	if m.afterGetFiles != nil {
+		m.afterGetFiles()
 	}
 	return results
 }


### PR DESCRIPTION
<!-- ship-stack:start -->
## PR stack

> [!NOTE]
> This PR is part of a stack. Merge it with the full stack when ready.

Depends on:
- #253

Followed by:
- #256
<!-- ship-stack:end -->

## Problem

An accepted import plan stores absolute episode source paths. A torrent client can move one of those sources after `/api/pack` builds the plan and before `/api/parse` creates hardlinks. The stale path then fails with `no such file or directory`, which can reduce achieved coverage below the configured threshold and abort the import.

Candidate success logs also identified only the announced pack, not the client releases that caused the candidate gate to pass.

## Fix

- Log each matching client release at `DEBUG` when the candidate gate passes.
- Detect missing hardlink sources, invalidate the client inventory and exact plan together, rebuild once, and retry the complete refreshed link set.
- Keep the recovery bounded to one refresh and preserve planned and achieved smart-mode coverage checks.
- Reuse hardlinks created by the first attempt through the existing idempotent hardlink behavior.
- Centralize cache invalidation and planned-coverage policy to keep all lifecycle paths consistent.
- Emit a static missing-source warning with a structured `source` field.

## Tests

- Authenticated candidate regression for every matching client release.
- Authenticated parse regression for a source move after planning and after one link already succeeds.
- Repeated-move regression proving the second missing source does not trigger another refresh.
- Refreshed-plan regression proving reduced smart-mode coverage prevents import.
- Hades service logs confirmed the original stale-source failure sequence.
