### PR TITLE
fix: use autobrr parser for episode title matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/autobrr/go-deluge v1.4.0
 	github.com/autobrr/go-qbittorrent v1.17.0
 	github.com/autobrr/go-torrent v1.1.0
+	github.com/autobrr/rls v0.9.0
 	github.com/dlclark/regexp2 v1.12.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-contrib/cors v1.7.7
@@ -16,7 +17,6 @@ require (
 	github.com/knadh/koanf/parsers/yaml v1.1.1
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/v2 v2.3.6
-	github.com/moistari/rls v0.6.0
 	github.com/mrobinsn/go-tvmaze v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/puzpuzpuz/xsync/v3 v3.5.1
@@ -78,7 +78,10 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.39.0 // indirect
+	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+// Pending https://github.com/autobrr/rls/pull/26.
+replace github.com/autobrr/rls v0.9.0 => github.com/nuxencs/rls v0.0.0-20260905093517-4be6135d5cac

--- a/go.sum
+++ b/go.sum
@@ -102,10 +102,10 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/moistari/rls v0.6.0 h1:9AWzsLaTN2zMTdUBkljQsUr5YlXxCQuHMhhoqBYUo5A=
-github.com/moistari/rls v0.6.0/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/mrobinsn/go-tvmaze v1.2.1 h1:02uIU4fkoUv/72LSQCrAc0Voki10IyhPADD0szIdp2M=
 github.com/mrobinsn/go-tvmaze v1.2.1/go.mod h1:rblHXZBJgp6fXZOcICvCuJx15mafIxhYoFYrGryGNgc=
+github.com/nuxencs/rls v0.0.0-20260905093517-4be6135d5cac h1:ypz9lZxcKfLoogFT+XV7gAbqq+u6HvypcyVMzIOWLKY=
+github.com/nuxencs/rls v0.0.0-20260905093517-4be6135d5cac/go.mod h1:WQDGkyT95o26XEdRIzP2CSXZFyufh8xvpQdckaC2khM=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -172,8 +172,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
-golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 )
 
 func ComparableTitle(r rls.Release, fuzzyMatching domain.FuzzyMatching) string {

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/http/processor.go
+++ b/internal/http/processor.go
@@ -23,8 +23,8 @@ import (
 	"github.com/nuxencs/seasonpackarr/internal/torrents"
 	"github.com/nuxencs/seasonpackarr/pkg/errors"
 
+	"github.com/autobrr/rls"
 	"github.com/gin-gonic/gin"
-	"github.com/moistari/rls"
 	"github.com/puzpuzpuz/xsync/v3"
 	"github.com/rs/zerolog"
 )

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -11,7 +11,7 @@ import (
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/internal/logger"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/singleflight"
 )

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/metadata/titles.go
+++ b/internal/metadata/titles.go
@@ -6,7 +6,7 @@ package metadata
 import (
 	"strings"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 )
 
 // maxVariantWords caps the longest shortened title variant. Provider searches

--- a/internal/metadata/tvdb.go
+++ b/internal/metadata/tvdb.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/nuxencs/seasonpackarr/pkg/errors"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 )
 
 type tvdbClient struct {

--- a/internal/metadata/tvdb_test.go
+++ b/internal/metadata/tvdb_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/metadata/tvmaze.go
+++ b/internal/metadata/tvmaze.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/nuxencs/seasonpackarr/pkg/errors"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 	"github.com/mrobinsn/go-tvmaze/tvmaze"
 )
 

--- a/internal/metadata/tvmaze_test.go
+++ b/internal/metadata/tvmaze_test.go
@@ -6,7 +6,7 @@ package metadata
 import (
 	"testing"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/release/parser_test.go
+++ b/internal/release/parser_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 - 2026, nuxen and the seasonpackarr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package release
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/rls"
+	"github.com/nuxencs/seasonpackarr/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCandidates_SiloWebTitle(t *testing.T) {
+	const packName = "Silo S03 1080p ATVP WEB-DL DDP 5.1 Atmos H.264-FLUX"
+	const episodeName = "Silo.S03E03.A.Dark.Web.1080p.ATVP.WEB-DL.DDP5.1.Atmos.H.264-FLUX.mkv"
+	const episodeSize = int64(3_961_454_446)
+
+	pack := rls.ParseString(packName)
+	episode := rls.ParseString(episodeName)
+	result := CheckCandidates(pack, episode, domain.FuzzyMatching{})
+	require.Equal(t, domain.StatusSuccessfulMatch, result.StatusCode, "%+v", result)
+
+	target := filepath.Join(packName, episodeName)
+	path, info := MatchEpToSeasonPackEp(episodeName, episodeSize, target, episodeSize)
+	require.Equal(t, target, path)
+	require.Equal(t, domain.CompareInfo{}, info)
+
+	otherSource := rls.ParseString(strings.Replace(episodeName, "WEB-DL", "WEB", 1))
+	result = CheckCandidates(pack, otherSource, domain.FuzzyMatching{})
+	require.Equal(t, domain.StatusSourceMismatch, result.StatusCode)
+}

--- a/internal/release/release.go
+++ b/internal/release/release.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nuxencs/seasonpackarr/internal/domain"
 	"github.com/nuxencs/seasonpackarr/internal/slices"
 
-	"github.com/moistari/rls"
+	"github.com/autobrr/rls"
 )
 
 func CheckCandidates(requestRls, clientRls rls.Release, fuzzyMatching domain.FuzzyMatching) domain.CompareInfo {


### PR DESCRIPTION
## Problem

A completed FLUX release of Silo S03E03, `A.Dark.Web`, was rejected when matching a WEB-DL season pack. The current parser reads `Web` in the episode title as the source, so the matcher reports a WEB versus WEB-DL mismatch and does not reuse the existing episode.

## Fix

Replace `moistari/rls` with `autobrr/rls`, which includes the title/source parsing fix. Keep the existing matching rules.

Pin commit `4be6135d5cac42c41f36175f58281616cbbc377a` from autobrr/rls#26 through a temporary Go module replacement. That commit also fixes EAC-3 audio parsing, including a TV case that the fork otherwise classifies as music. Remove the replacement when an upstream version includes the fix.

## Tests

- Add the exact Silo pack and episode names as a regression case. Check candidate acceptance and file matching at the recorded episode size.
- Check that a WEB episode still fails the source comparison against the WEB-DL pack.
